### PR TITLE
Bugfix - Wrong interface orientation behaviour at start time

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -8,6 +8,8 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   private var mEventEmitter = OrientationEventManager(context)
   private var mSensorListener = OrientationSensorListener(context)
   private var mLifecycleListener = OrientationLifecycleListener()
+
+  private var initialScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   private var lastInterfaceOrientation = Orientation.UNKNOWN
   private var lastDeviceOrientation = Orientation.UNKNOWN
   private var initialized = false
@@ -40,6 +42,8 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
       mSensorListener.disable()
     }
 
+    initialScreenOrientation =
+      context.currentActivity?.requestedOrientation ?: initialScreenOrientation
     lastInterfaceOrientation = initInterfaceOrientation()
     lastDeviceOrientation = initDeviceOrientation()
     isLocked = initIsLocked()

--- a/ios/OrientationDirector.mm
+++ b/ios/OrientationDirector.mm
@@ -64,7 +64,7 @@ RCT_EXPORT_MODULE()
 
 + (UIInterfaceOrientationMask)getSupportedInterfaceOrientationsForWindow
 {
-    return [_director supportedInterfaceOrientation];
+    return [_director supportedInterfaceOrientations];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
Currently this module doesn't follow the screenOrientation or the UISupportedInterfaceOrientation settings.

On iOS, at start time, supportedInterfaceOrientations is overridden with the following value: UIInterfaceOrientationMask.all, therefore the Info.plist value is useless and the app doesn't act accordingly.
On Android we don't override the screenOrientation value, although before the isLocked feature, the interface orientation on js would follow the device orientation incorrectly. Now it can't follow the device orientation since there is a condition that returns if isLocked is true and we compute its value at start time based on the screenOrientation setting.

To fix this issue on iOS, we read the Info.plist value, combine each UIInterfaceOrientationMask value and set the supportedInterfaceOrientations accordingly.
Even tho this issue on Android is fixed, we still implement an initialScreenOrientation property.