### PR TITLE
Bugfix - Android screen orientation locked breaks initial interface orientation value

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -9,7 +9,7 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   private var mSensorListener = OrientationSensorListener(context)
   private var mLifecycleListener = OrientationLifecycleListener()
 
-  private var initialScreenOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+  private var initialSupportedInterfaceOrientations = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   private var lastInterfaceOrientation = Orientation.UNKNOWN
   private var lastDeviceOrientation = Orientation.UNKNOWN
   private var initialized = false
@@ -42,8 +42,8 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
       mSensorListener.disable()
     }
 
-    initialScreenOrientation =
-      context.currentActivity?.requestedOrientation ?: initialScreenOrientation
+    initialSupportedInterfaceOrientations =
+      context.currentActivity?.requestedOrientation ?: initialSupportedInterfaceOrientations
     lastInterfaceOrientation = initInterfaceOrientation()
     lastDeviceOrientation = initDeviceOrientation()
     isLocked = initIsLocked()

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -4,7 +4,7 @@ import android.content.pm.ActivityInfo
 import com.facebook.react.bridge.ReactApplicationContext
 
 class OrientationDirectorImpl internal constructor(private val context: ReactApplicationContext) {
-  private var mUtils = OrientationDirectorUtilsImpl()
+  private var mUtils = OrientationDirectorUtilsImpl(context)
   private var mEventEmitter = OrientationEventManager(context)
   private var mSensorListener = OrientationSensorListener(context)
   private var mLifecycleListener = OrientationLifecycleListener()
@@ -76,18 +76,8 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   }
 
   private fun initInterfaceOrientation(): Orientation {
-    val activityOrientation = context.currentActivity!!.requestedOrientation
-    if (
-      mUtils.isActivityInPortraitOrientation(activityOrientation) ||
-      mUtils.isActivityInLandscapeOrientation(activityOrientation)
-    ) {
-      return mUtils.getInterfaceOrientationFrom(activityOrientation)
-    }
-
-    val lastRotationDetected = mSensorListener.getLastRotationDetected()
-      ?: return lastInterfaceOrientation
-
-    return mUtils.getDeviceOrientationFrom(lastRotationDetected)
+    val rotation = mUtils.getInterfaceRotation()
+    return mUtils.getOrientationFromRotation(rotation)
   }
 
   private fun initDeviceOrientation(): Orientation {
@@ -116,7 +106,7 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   }
 
   private fun adaptInterfaceTo(deviceOrientation: Orientation) {
-    if (isLocked) {
+    if (isLocked && lastInterfaceOrientation != Orientation.UNKNOWN) {
       return
     }
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -60,7 +60,7 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   }
 
   fun lockTo(jsOrientation: Int) {
-    val interfaceOrientation = mUtils.getOrientationEnumFrom(jsOrientation)
+    val interfaceOrientation = mUtils.getOrientationFromJsOrientation(jsOrientation)
     val screenOrientation =
       mUtils.getActivityOrientationFrom(interfaceOrientation)
     context.currentActivity?.requestedOrientation = screenOrientation

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -106,7 +106,7 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   }
 
   private fun adaptInterfaceTo(deviceOrientation: Orientation) {
-    if (isLocked && lastInterfaceOrientation != Orientation.UNKNOWN) {
+    if (isLocked) {
       return
     }
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
@@ -1,8 +1,23 @@
 package com.orientationdirector.implementation
 
+import android.content.Context
 import android.content.pm.ActivityInfo
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
+import com.facebook.react.bridge.ReactContext
 
-class OrientationDirectorUtilsImpl() {
+class OrientationDirectorUtilsImpl(val context: ReactContext) {
+
+  fun getInterfaceRotation(): Int {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      context.currentActivity?.display?.rotation ?: Surface.ROTATION_0
+    } else {
+      val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+      @Suppress("DEPRECATION")
+      windowManager.defaultDisplay.rotation
+    }
+  }
 
   fun getDeviceOrientationFrom(rotation: Int): Orientation {
     var orientation = Orientation.UNKNOWN
@@ -22,29 +37,6 @@ class OrientationDirectorUtilsImpl() {
     return orientation
   }
 
-  fun getInterfaceOrientationFrom(activityInfo: Int): Orientation {
-    return when (activityInfo) {
-      ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE -> Orientation.LANDSCAPE_RIGHT
-      ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT -> Orientation.PORTRAIT_UPSIDE_DOWN
-      ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE -> Orientation.LANDSCAPE_LEFT
-      else -> Orientation.PORTRAIT
-    };
-  }
-
-  fun isActivityInLandscapeOrientation(orientation: Int): Boolean {
-    return listOf(
-      ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
-      ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
-    ).contains(orientation);
-  }
-
-  fun isActivityInPortraitOrientation(orientation: Int): Boolean {
-    return listOf(
-      ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
-      ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
-    ).contains(orientation);
-  }
-
   fun getActivityOrientationFrom(interfaceOrientation: Orientation): Int {
     return when (interfaceOrientation) {
       Orientation.LANDSCAPE_RIGHT -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
@@ -59,6 +51,15 @@ class OrientationDirectorUtilsImpl() {
       2 -> Orientation.LANDSCAPE_RIGHT
       3 -> Orientation.PORTRAIT_UPSIDE_DOWN
       4 -> Orientation.LANDSCAPE_LEFT
+      else -> Orientation.PORTRAIT
+    }
+  }
+
+  fun getOrientationFromRotation(rotation: Int): Orientation {
+    return when(rotation) {
+      Surface.ROTATION_270 -> Orientation.LANDSCAPE_RIGHT
+      Surface.ROTATION_90 -> Orientation.LANDSCAPE_LEFT
+      Surface.ROTATION_180 -> Orientation.PORTRAIT_UPSIDE_DOWN
       else -> Orientation.PORTRAIT
     }
   }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
@@ -46,7 +46,7 @@ class OrientationDirectorUtilsImpl(val context: ReactContext) {
     }
   }
 
-  fun getOrientationEnumFrom(jsOrientation: Int): Orientation {
+  fun getOrientationFromJsOrientation(jsOrientation: Int): Orientation {
     return when (jsOrientation) {
       2 -> Orientation.LANDSCAPE_RIGHT
       3 -> Orientation.PORTRAIT_UPSIDE_DOWN


### PR DESCRIPTION
I've written the initInitialOrientation logic from scratch, leveraging a leaner implementation that uses the display current rotation to convert it in a given Orientation.

This approach is cleaner and more correct since the old implementation relied upon requestOrientation that is setting based and from the deviceOrientation, although at init phase we haven't got any recorded device orientation yet.

I've also renamed the initialScreenOrientation to something more appropriate like in iOS.