### PR TITLE
Bugfix - android interface orientation value changes even with auto rotation off

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationAutoRotationObserver.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationAutoRotationObserver.kt
@@ -1,0 +1,50 @@
+package com.orientationdirector.implementation
+
+import android.database.ContentObserver
+import android.os.Handler
+import android.provider.Settings
+import android.util.Log
+import com.facebook.react.bridge.ReactContext
+
+class OrientationAutoRotationObserver(val context: ReactContext, handler: Handler?) : ContentObserver(handler) {
+  private var lastAutoRotationStatus: Boolean = isAutoRotationEnabled()
+
+  fun getLastAutoRotationStatus(): Boolean {
+    return lastAutoRotationStatus
+  }
+
+  override fun onChange(selfChange: Boolean) {
+    super.onChange(selfChange)
+    Log.d(NAME, "onChange")
+    val status = isAutoRotationEnabled()
+    Log.d(NAME, "onChange - status: $status")
+    lastAutoRotationStatus = status
+  }
+
+  fun enable() {
+    Log.d(NAME, "enable")
+    context.contentResolver.registerContentObserver(
+      Settings.System.getUriFor(Settings.System.ACCELEROMETER_ROTATION),
+      true,
+      this,
+    )
+  }
+
+  fun disable() {
+    Log.d(NAME, "disable")
+    context.contentResolver.unregisterContentObserver(this)
+  }
+
+  private fun isAutoRotationEnabled(): Boolean {
+    Log.d(NAME, "isAutoRotationEnabled")
+    return try {
+      Settings.System.getInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION) == 1;
+    } catch (ex: Settings.SettingNotFoundException) {
+      false
+    }
+  }
+
+  companion object {
+    const val NAME = "AutoRotationObserver"
+  }
+}

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationAutoRotationObserver.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationAutoRotationObserver.kt
@@ -15,14 +15,11 @@ class OrientationAutoRotationObserver(val context: ReactContext, handler: Handle
 
   override fun onChange(selfChange: Boolean) {
     super.onChange(selfChange)
-    Log.d(NAME, "onChange")
     val status = isAutoRotationEnabled()
-    Log.d(NAME, "onChange - status: $status")
     lastAutoRotationStatus = status
   }
 
   fun enable() {
-    Log.d(NAME, "enable")
     context.contentResolver.registerContentObserver(
       Settings.System.getUriFor(Settings.System.ACCELEROMETER_ROTATION),
       true,
@@ -31,12 +28,10 @@ class OrientationAutoRotationObserver(val context: ReactContext, handler: Handle
   }
 
   fun disable() {
-    Log.d(NAME, "disable")
     context.contentResolver.unregisterContentObserver(this)
   }
 
   private fun isAutoRotationEnabled(): Boolean {
-    Log.d(NAME, "isAutoRotationEnabled")
     return try {
       Settings.System.getInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION) == 1;
     } catch (ex: Settings.SettingNotFoundException) {

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -106,6 +106,10 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
   }
 
   private fun adaptInterfaceTo(deviceOrientation: Orientation) {
+    if (!mUtils.isAutoRotationEnabled()) {
+      return
+    }
+
     if (isLocked) {
       return
     }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
@@ -3,6 +3,7 @@ package com.orientationdirector.implementation
 import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Build
+import android.provider.Settings
 import android.view.Surface
 import android.view.WindowManager
 import com.facebook.react.bridge.ReactContext
@@ -61,6 +62,14 @@ class OrientationDirectorUtilsImpl(val context: ReactContext) {
       Surface.ROTATION_90 -> Orientation.LANDSCAPE_LEFT
       Surface.ROTATION_180 -> Orientation.PORTRAIT_UPSIDE_DOWN
       else -> Orientation.PORTRAIT
+    }
+  }
+
+  fun isAutoRotationEnabled(): Boolean {
+    return try {
+      Settings.System.getInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION) == 1;
+    } catch (ex: Settings.SettingNotFoundException) {
+      false
     }
   }
 }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
@@ -64,12 +64,4 @@ class OrientationDirectorUtilsImpl(val context: ReactContext) {
       else -> Orientation.PORTRAIT
     }
   }
-
-  fun isAutoRotationEnabled(): Boolean {
-    return try {
-      Settings.System.getInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION) == 1;
-    } catch (ex: Settings.SettingNotFoundException) {
-      false
-    }
-  }
 }


### PR DESCRIPTION
I've created a new class: OrientationAutoRotationObserver that implements ContentObserver and checks whether autoRotation setting is changed.
This value is then used inside adaptInterfaceTo method to check if interface can follow device rotation.

Note: an issue still persists and is the following:
If the user disables autoRotation and uses the icon that appears in the bottom bar whenever the device is in landscape, then there is no way i found to listen to that change and update interface orientation value.