### PR TITLE
Feature - reset to initial supported interface orientation

### DIFF
--- a/android/src/main/java/com/orientationdirector/OrientationDirectorModule.kt
+++ b/android/src/main/java/com/orientationdirector/OrientationDirectorModule.kt
@@ -38,6 +38,11 @@ class OrientationDirectorModule internal constructor(context: ReactApplicationCo
     orientationDirectorImpl.unlock()
   }
 
+  @ReactMethod()
+  override fun resetSupportedInterfaceOrientations() {
+    orientationDirectorImpl.resetSupportedInterfaceOrientations()
+  }
+
   @ReactMethod(isBlockingSynchronousMethod = true)
   override fun isLocked(): Boolean {
     return orientationDirectorImpl.getIsLocked()

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -95,6 +95,12 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
     adaptInterfaceTo(getDeviceOrientation())
   }
 
+  fun resetSupportedInterfaceOrientations() {
+    context.currentActivity?.requestedOrientation = initialSupportedInterfaceOrientations
+    updateIsLockedTo(initIsLocked())
+    updateLastInterfaceOrientationTo(initInterfaceOrientation())
+  }
+
   private fun initInterfaceOrientation(): Orientation {
     val rotation = mUtils.getInterfaceRotation()
     return mUtils.getOrientationFromRotation(rotation)
@@ -138,13 +144,17 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
       return
     }
 
-    lastInterfaceOrientation = deviceOrientation
-    mEventEmitter.sendInterfaceOrientationDidChange(lastInterfaceOrientation.ordinal)
+    updateLastInterfaceOrientationTo(deviceOrientation)
   }
 
   private fun updateIsLockedTo(value: Boolean) {
     mEventEmitter.sendLockDidChange(value)
     isLocked = value
+  }
+
+  private fun updateLastInterfaceOrientationTo(value: Orientation) {
+    lastInterfaceOrientation = value
+    mEventEmitter.sendInterfaceOrientationDidChange(value.ordinal)
   }
 
   companion object {

--- a/android/src/oldarch/OrientationDirectorSpec.kt
+++ b/android/src/oldarch/OrientationDirectorSpec.kt
@@ -10,6 +10,7 @@ abstract class OrientationDirectorSpec internal constructor(context: ReactApplic
   abstract fun getDeviceOrientation(promise: Promise)
   abstract fun lockTo(orientation: Double)
   abstract fun unlock()
+  abstract fun resetSupportedInterfaceOrientations()
   abstract fun isLocked(): Boolean
   abstract fun isAutoRotationEnabled(): Boolean
   abstract fun addListener(eventName: String)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -935,7 +935,7 @@ PODS:
   - React-Mapbuffer (0.74.1):
     - glog
     - React-debug
-  - react-native-orientation-director (1.0.1):
+  - react-native-orientation-director (1.1.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1395,7 +1395,7 @@ SPEC CHECKSUMS:
   React-jsitracing: 233d1a798fe0ff33b8e630b8f00f62c4a8115fbc
   React-logger: 7e7403a2b14c97f847d90763af76b84b152b6fce
   React-Mapbuffer: 11029dcd47c5c9e057a4092ab9c2a8d10a496a33
-  react-native-orientation-director: bafe197333f56bc7e25ad17542f159518b1cf3d0
+  react-native-orientation-director: 69687eb441507b1c2061dfffe0feb40be19db554
   React-nativeconfig: b0073a590774e8b35192fead188a36d1dca23dec
   React-NativeModulesApple: df46ff3e3de5b842b30b4ca8a6caae6d7c8ab09f
   React-perflogger: 3d31e0d1e8ad891e43a09ac70b7b17a79773003a

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, StyleSheet, Text, View } from 'react-native';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
 import RNOrientationDirector, {
   Orientation,
   useDeviceOrientation,
@@ -14,7 +14,10 @@ export default function App() {
   const isInterfaceOrientationLocked = useIsInterfaceOrientationLocked();
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainerStyle}
+    >
       <Text style={[styles.text, styles.marginBottom]}>
         Current Interface Orientation:
         {RNOrientationDirector.convertOrientationToHumanReadableString(
@@ -102,15 +105,25 @@ export default function App() {
           RNOrientationDirector.unlock();
         }}
       />
-    </View>
+      <View style={styles.marginBottom} />
+      <Button
+        title={'Reset'}
+        onPress={() => {
+          RNOrientationDirector.resetSupportedInterfaceOrientations();
+        }}
+      />
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  contentContainerStyle: {
     alignItems: 'center',
     justifyContent: 'center',
+    flexGrow: 1,
   },
   text: {
     color: 'black',

--- a/ios/OrientationDirector.mm
+++ b/ios/OrientationDirector.mm
@@ -123,6 +123,18 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isLocked)
     return @([_director isLocked]);
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)resetSupportedInterfaceOrientations
+#else
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(resetSupportedInterfaceOrientations)
+#endif
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_director resetSupportedInterfaceOrientations];
+    });
+}
+
+
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/ios/implementation/OrientationDirectorImpl.swift
+++ b/ios/implementation/OrientationDirectorImpl.swift
@@ -77,10 +77,14 @@ import UIKit
         if (isLastInterfaceOrientationAlreadySupported) {
             return
         }
+
+        let supportedInterfaceOrientations = OrientationDirectorUtils.readSupportedInterfaceOrientationsFromBundle()
+        guard let firstSupportedInterfaceOrientation = supportedInterfaceOrientations.first else {
+            return
+        }
         
-        // It always defaults to Portrait whenever we reset the supported interfaces 
-        // and we've previously locked the interface to an unsupported interface.
-        self.updateLastInterfaceOrientation(value: Orientation.PORTRAIT)
+        let orientation = OrientationDirectorUtils.getOrientationFrom(mask: firstSupportedInterfaceOrientation)
+        self.updateLastInterfaceOrientation(value: orientation)
     }
 
     private func initInitialSupportedInterfaceOrientations() -> UIInterfaceOrientationMask {

--- a/ios/implementation/OrientationDirectorImpl.swift
+++ b/ios/implementation/OrientationDirectorImpl.swift
@@ -66,6 +66,22 @@ import UIKit
         updateIsLockedTo(value: false)
         self.adaptInterfaceTo(deviceOrientation: deviceOrientation)
     }
+    
+    @objc public func resetSupportedInterfaceOrientations() {
+        self.supportedInterfaceOrientations = self.initialSupportedInterfaceOrientations
+        self.requestInterfaceUpdateTo(mask: self.supportedInterfaceOrientations)
+        self.updateIsLockedTo(value: self.initIsLocked())
+
+        let lastMask = OrientationDirectorUtils.getMaskFrom(orientation: lastInterfaceOrientation)
+        let isLastInterfaceOrientationAlreadySupported = self.supportedInterfaceOrientations.contains(lastMask)
+        if (isLastInterfaceOrientationAlreadySupported) {
+            return
+        }
+        
+        // It always defaults to Portrait whenever we reset the supported interfaces 
+        // and we've previously locked the interface to an unsupported interface.
+        self.updateLastInterfaceOrientation(value: Orientation.PORTRAIT)
+    }
 
     private func initInitialSupportedInterfaceOrientations() -> UIInterfaceOrientationMask {
         let supportedInterfaceOrientations = OrientationDirectorUtils.readSupportedInterfaceOrientationsFromBundle()
@@ -139,12 +155,16 @@ import UIKit
           return
         }
 
-        self.eventManager.sendInterfaceOrientationDidChange(orientationValue: deviceOrientation.rawValue)
-        lastInterfaceOrientation = deviceOrientation
+        updateLastInterfaceOrientation(value: deviceOrientation)
     }
 
     private func updateIsLockedTo(value: Bool) {
         eventManager.sendLockDidChange(value: value)
         isLocked = value
+    }
+    
+    private func updateLastInterfaceOrientation(value: Orientation) {
+        self.eventManager.sendInterfaceOrientationDidChange(orientationValue: value.rawValue)
+        lastInterfaceOrientation = value
     }
 }

--- a/ios/implementation/OrientationDirectorUtils.swift
+++ b/ios/implementation/OrientationDirectorUtils.swift
@@ -65,6 +65,23 @@ class OrientationDirectorUtils {
 
         return orientation
     }
+    
+    public static func getOrientationFrom(mask: UIInterfaceOrientationMask) -> Orientation {
+        var orientation = Orientation.UNKNOWN
+        
+        switch(mask) {
+        case UIInterfaceOrientationMask.portraitUpsideDown:
+            orientation = Orientation.PORTRAIT_UPSIDE_DOWN
+        case UIInterfaceOrientationMask.landscapeRight:
+            orientation = Orientation.LANDSCAPE_LEFT
+        case UIInterfaceOrientationMask.landscapeLeft:
+            orientation = Orientation.LANDSCAPE_RIGHT
+        default:
+            orientation = Orientation.PORTRAIT
+        }
+
+        return orientation
+    }
 
     /*
         Note: .portraitUpsideDown only works for devices with home button

--- a/src/NativeOrientationDirector.ts
+++ b/src/NativeOrientationDirector.ts
@@ -8,6 +8,7 @@ export interface Spec extends TurboModule {
   unlock(): void;
   isLocked(): boolean;
   isAutoRotationEnabled(): boolean;
+  resetSupportedInterfaceOrientations(): void;
 
   addListener: (eventType: string) => void;
   removeListeners: (count: number) => void;

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -55,6 +55,10 @@ class RNOrientationDirector {
       : AutoRotation.disabled;
   }
 
+  static resetSupportedInterfaceOrientations(): void {
+    Module.resetSupportedInterfaceOrientations();
+  }
+
   static listenForDeviceOrientationChanges(
     callback: (orientation: OrientationEvent) => void
   ) {


### PR DESCRIPTION
This PR implements a new method called: resetSupportedInterfaceOrientations that reverts the current setup to the initial one: activity's screenOrientation or info.plist UISupportedInterfaceOrientations.