### PR TITLE
Bugfix - iOS missing check if deviceOrientation is actually supported

### DIFF
--- a/ios/implementation/OrientationDirectorImpl.swift
+++ b/ios/implementation/OrientationDirectorImpl.swift
@@ -66,7 +66,7 @@ import UIKit
         updateIsLockedTo(value: false)
         self.adaptInterfaceTo(deviceOrientation: deviceOrientation)
     }
-    
+
     @objc public func resetSupportedInterfaceOrientations() {
         self.supportedInterfaceOrientations = self.initialSupportedInterfaceOrientations
         self.requestInterfaceUpdateTo(mask: self.supportedInterfaceOrientations)
@@ -82,7 +82,7 @@ import UIKit
         guard let firstSupportedInterfaceOrientation = supportedInterfaceOrientations.first else {
             return
         }
-        
+
         let orientation = OrientationDirectorUtils.getOrientationFrom(mask: firstSupportedInterfaceOrientation)
         self.updateLastInterfaceOrientation(value: orientation)
     }
@@ -155,8 +155,10 @@ import UIKit
           return
         }
 
-        if (deviceOrientation == Orientation.FACE_UP || deviceOrientation == Orientation.FACE_DOWN) {
-          return
+        let deviceOrientationMask = OrientationDirectorUtils.getMaskFrom(orientation: deviceOrientation)
+        let isDeviceOrientationMaskSupported = self.supportedInterfaceOrientations.contains(deviceOrientationMask)
+        if (!isDeviceOrientationMaskSupported) {
+            return
         }
 
         updateLastInterfaceOrientation(value: deviceOrientation)
@@ -166,7 +168,7 @@ import UIKit
         eventManager.sendLockDidChange(value: value)
         isLocked = value
     }
-    
+
     private func updateLastInterfaceOrientation(value: Orientation) {
         self.eventManager.sendInterfaceOrientationDidChange(orientationValue: value.rawValue)
         lastInterfaceOrientation = value


### PR DESCRIPTION
This PR implements a missing check in adaptInterfaceTo method.
Currently this method executes an interface orientation value update even when the device orientation is not supported, therefore there is a bug in which we see the interface orientation value getting updated to a wrong value even tho the actual interface is not updating to match it.