### PR TITLE
Bugfix: interface orientation should match bottom bar position

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorImpl.kt
@@ -79,20 +79,21 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
     return mAutoRotationObserver.getLastAutoRotationStatus()
   }
 
-  fun lockTo(jsOrientation: Int) {
-    val interfaceOrientation = mUtils.getOrientationFromJsOrientation(jsOrientation)
+  fun lockTo(rawJsOrientation: Int) {
+    val jsOrientation = mUtils.getOrientationFromJsOrientation(rawJsOrientation)
     val screenOrientation =
-      mUtils.getActivityOrientationFrom(interfaceOrientation)
+      mUtils.getActivityOrientationFrom(jsOrientation)
     context.currentActivity?.requestedOrientation = screenOrientation
-    mEventEmitter.sendInterfaceOrientationDidChange(interfaceOrientation.ordinal)
-    lastInterfaceOrientation = interfaceOrientation
+
     updateIsLockedTo(true)
+    updateLastInterfaceOrientationTo(jsOrientation)
   }
 
   fun unlock() {
     context.currentActivity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+
     updateIsLockedTo(false)
-    adaptInterfaceTo(getDeviceOrientation())
+    adaptInterfaceTo(lastDeviceOrientation)
   }
 
   fun resetSupportedInterfaceOrientations() {
@@ -140,11 +141,12 @@ class OrientationDirectorImpl internal constructor(private val context: ReactApp
       return
     }
 
-    if (lastInterfaceOrientation == deviceOrientation) {
+    val newInterfaceOrientation = mUtils.getInterfaceOrientationFromDeviceOrientation(deviceOrientation);
+    if (newInterfaceOrientation == lastInterfaceOrientation) {
       return
     }
 
-    updateLastInterfaceOrientationTo(deviceOrientation)
+    updateLastInterfaceOrientationTo(newInterfaceOrientation)
   }
 
   private fun updateIsLockedTo(value: Boolean) {

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorUtilsImpl.kt
@@ -64,4 +64,14 @@ class OrientationDirectorUtilsImpl(val context: ReactContext) {
       else -> Orientation.PORTRAIT
     }
   }
+
+  fun getInterfaceOrientationFromDeviceOrientation(deviceOrientation: Orientation): Orientation {
+    return when(deviceOrientation) {
+      Orientation.PORTRAIT -> Orientation.PORTRAIT
+      Orientation.LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_LEFT
+      Orientation.PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN
+      Orientation.LANDSCAPE_LEFT -> Orientation.LANDSCAPE_RIGHT
+      else -> Orientation.UNKNOWN
+    }
+  }
 }

--- a/ios/OrientationDirector.mm
+++ b/ios/OrientationDirector.mm
@@ -99,7 +99,7 @@ RCT_EXPORT_METHOD(lockTo:(double)jsOrientation)
 {
     NSNumber *jsOrientationNumber = @(jsOrientation);
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_director lockToJsOrientation:jsOrientationNumber];
+        [_director lockToRawJsOrientation:jsOrientationNumber];
     });
 }
 

--- a/ios/implementation/OrientationDirectorUtils.swift
+++ b/ios/implementation/OrientationDirectorUtils.swift
@@ -15,12 +15,12 @@ class OrientationDirectorUtils {
         var orientation = Orientation.UNKNOWN
 
         switch(uiInterfaceOrientation) {
-        case UIInterfaceOrientation.landscapeRight: // Home button on the right
-            orientation = Orientation.LANDSCAPE_LEFT
+        case UIInterfaceOrientation.landscapeRight:
+            orientation = Orientation.LANDSCAPE_RIGHT
         case UIInterfaceOrientation.portraitUpsideDown:
             orientation = Orientation.PORTRAIT_UPSIDE_DOWN
-        case UIInterfaceOrientation.landscapeLeft: // Home button on the left
-            orientation = Orientation.LANDSCAPE_RIGHT
+        case UIInterfaceOrientation.landscapeLeft:
+            orientation = Orientation.LANDSCAPE_LEFT
         default:
             orientation = Orientation.PORTRAIT
         }
@@ -73,9 +73,9 @@ class OrientationDirectorUtils {
         case UIInterfaceOrientationMask.portraitUpsideDown:
             orientation = Orientation.PORTRAIT_UPSIDE_DOWN
         case UIInterfaceOrientationMask.landscapeRight:
-            orientation = Orientation.LANDSCAPE_LEFT
-        case UIInterfaceOrientationMask.landscapeLeft:
             orientation = Orientation.LANDSCAPE_RIGHT
+        case UIInterfaceOrientationMask.landscapeLeft:
+            orientation = Orientation.LANDSCAPE_LEFT
         default:
             orientation = Orientation.PORTRAIT
         }
@@ -83,25 +83,42 @@ class OrientationDirectorUtils {
         return orientation
     }
 
-    /*
-        Note: .portraitUpsideDown only works for devices with home button
-        //https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations
+    /**
+     Note: .portraitUpsideDown only works for devices with home button and iPads
+     https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations
      */
-    public static func getMaskFrom(orientation: Orientation) -> UIInterfaceOrientationMask {
-        var mask = UIInterfaceOrientationMask.portrait
-
-        switch(orientation) {
+    public static func getMaskFrom(jsOrientation: Orientation) -> UIInterfaceOrientationMask {
+        switch(jsOrientation) {
+        case Orientation.PORTRAIT:
+            return UIInterfaceOrientationMask.portrait
         case Orientation.LANDSCAPE_RIGHT:
-            mask = UIInterfaceOrientationMask.landscapeLeft
+            return UIInterfaceOrientationMask.landscapeRight
         case Orientation.PORTRAIT_UPSIDE_DOWN:
-            mask = UIInterfaceOrientationMask.portraitUpsideDown
+            return UIInterfaceOrientationMask.portraitUpsideDown
         case Orientation.LANDSCAPE_LEFT:
-            mask = UIInterfaceOrientationMask.landscapeRight
+            return UIInterfaceOrientationMask.landscapeLeft
         default:
-            mask = UIInterfaceOrientationMask.portrait
+            return UIInterfaceOrientationMask.all
         }
-
-        return mask
+    }
+    
+    /**
+     Note: .portraitUpsideDown only works for devices with home button and iPads
+     https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations
+     */
+    public static func getMaskFrom(deviceOrientation: Orientation) -> UIInterfaceOrientationMask {
+        switch(deviceOrientation) {
+        case Orientation.PORTRAIT:
+            return UIInterfaceOrientationMask.portrait
+        case Orientation.LANDSCAPE_RIGHT:
+            return UIInterfaceOrientationMask.landscapeLeft
+        case Orientation.PORTRAIT_UPSIDE_DOWN:
+            return UIInterfaceOrientationMask.portraitUpsideDown
+        case Orientation.LANDSCAPE_LEFT:
+            return UIInterfaceOrientationMask.landscapeRight
+        default:
+            return UIInterfaceOrientationMask.all
+        }
     }
 
     public static func getInterfaceOrientation() -> UIInterfaceOrientation {


### PR DESCRIPTION
This PR resets the Orientation computations so that the following statements is true:
"When the device is in landscape left, then the interface orientation is rotate on the right and viceversa, both in iOS and Android"