### PR TITLE
feat: implement missing device orientations on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can install the package via npm or yarn:
 ```sh
 npm install react-native-orientation-director
 ```
+
 ```sh
 yarn add react-native-orientation-director
 ```
@@ -71,27 +72,27 @@ There is no need to do anything in Android, it works out of the box.
 
 This library exports a class called: [RNOrientationDirector](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/RNOrientationDirector.ts) that exposes the following methods:
 
-| Method                                  | Description                                                                     |
-|-----------------------------------------|---------------------------------------------------------------------------------|
-| getInterfaceOrientation                 | Returns the last interface orientation                                          |
-| getDeviceOrientation                    | Returns the last device orientation                                             |
-| lockTo                                  | Locks the interface to a specific orientation                                   |
-| unlock                                  | Unlock the interface                                                            |
-| isLocked                                | Returns the current interface orientation status (locked / unlocked)            |
-| isAutoRotationEnabled                   | (Android Only) Returns if auto rotation is enabled                              |
-| listenForDeviceOrientationChanges       | Triggers a provided callback each time the device orientation changes           |
-| listenForInterfaceOrientationChanges    | Triggers a provided callback each time the interface orientation changes        |
-| listenForLockChanges                    | Triggers a provided callback each time the interface orientation status changes |
-| convertOrientationToHumanReadableString | Returns a human readable string based on the given orientation                  |
+| Method                                   | Description                                                                       |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| getInterfaceOrientation                  | Returns the last interface orientation                                            |
+| getDeviceOrientation                     | Returns the last device orientation                                               |
+| lockTo                                   | Locks the interface to a specific orientation                                     |
+| unlock                                   | Unlock the interface                                                              |
+| isLocked                                 | Returns the current interface orientation status (locked / unlocked)              |
+| isAutoRotationEnabled                    | (Android Only) Returns if auto rotation is enabled                                |
+| listenForDeviceOrientationChanges        | Triggers a provided callback each time the device orientation changes             |
+| listenForInterfaceOrientationChanges     | Triggers a provided callback each time the interface orientation changes          |
+| listenForLockChanges                     | Triggers a provided callback each time the interface orientation status changes   |
+| convertOrientationToHumanReadableString  | Returns a human readable string based on the given orientation                    |
 | convertAutoRotationToHumanReadableString | Returns a human readable string based on the given auto rotation                  |
-| setHumanReadableOrientations              | Sets the mapping needed to convert orientation values to human readable strings |
-| setHumanReadableAutoRotations              | Sets the mapping needed to convert auto rotation values to human readable strings |
-| resetSupportedInterfaceOrientations     | Resets the supported interface orientations to settings                         |
+| setHumanReadableOrientations             | Sets the mapping needed to convert orientation values to human readable strings   |
+| setHumanReadableAutoRotations            | Sets the mapping needed to convert auto rotation values to human readable strings |
+| resetSupportedInterfaceOrientations      | Resets the supported interface orientations to settings                           |
 
 In addition, the library exposes the following hooks:
 
 | Hook                                                                                                                                                            | Description                                                             |
-|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | [useInterfaceOrientation](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useInterfaceOrientation.hook.ts)                 | Returns the current interface orientation and listens to changes        |
 | [useDeviceOrientation](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useDeviceOrientation.hook.ts)                       | Returns the current device orientation and listens to changes           |
 | [useIsInterfaceOrientationLocked](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useIsInterfaceOrientationLocked.hook.ts) | Returns the current interface orientation status and listens to changes |

--- a/android/src/main/java/com/orientationdirector/implementation/EventManager.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/EventManager.kt
@@ -1,6 +1,5 @@
 package com.orientationdirector.implementation
 
-import android.util.Log
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap

--- a/android/src/main/java/com/orientationdirector/implementation/LifecycleListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/LifecycleListener.kt
@@ -2,7 +2,7 @@ package com.orientationdirector.implementation
 
 import com.facebook.react.bridge.LifecycleEventListener
 
-class LifecycleListener() : LifecycleEventListener {
+class LifecycleListener : LifecycleEventListener {
 
   private var onHostResumeCallback: (() -> Unit)? = null
   private var onHostPauseCallback: (() -> Unit)? = null

--- a/android/src/main/java/com/orientationdirector/implementation/Orientation.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Orientation.kt
@@ -9,4 +9,6 @@ enum class Orientation {
   LANDSCAPE_RIGHT,
   PORTRAIT_UPSIDE_DOWN,
   LANDSCAPE_LEFT,
+  FACE_UP,
+  FACE_DOWN,
 }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -3,7 +3,6 @@ package com.orientationdirector.implementation
 import android.content.pm.ActivityInfo
 import android.os.Handler
 import android.os.Looper
-import android.view.OrientationEventListener.ORIENTATION_UNKNOWN
 import com.facebook.react.bridge.ReactApplicationContext
 
 class OrientationDirectorModuleImpl internal constructor(private val context: ReactApplicationContext) {
@@ -24,24 +23,14 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private var isLocked: Boolean = false
 
   init {
-    mSensorListener.setOnOrientationChangedCallback { orientation ->
-      onOrientationChanged(orientation)
+    mSensorListener.setOnOrientationAnglesChangedCallback { orientation ->
+      onOrientationAnglesChanged(orientation)
     }
-
-//    if (mSensorListener.canDetectOrientation()) {
-//      mSensorListener.enable()
-//    } else {
-//      mSensorListener.disable()
-//    }
 
     mAutoRotationObserver.enable()
 
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
-//      if (mSensorListener.canDetectOrientation()) {
-//        mSensorListener.enable()
-//      }
-
       mSensorListener.enable()
       mAutoRotationObserver.enable()
     }
@@ -110,10 +99,8 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   }
 
   private fun initDeviceOrientation(): Orientation {
-    val lastRotationDetected = mSensorListener.getLastRotationDetected()
-      ?: return Orientation.UNKNOWN
-
-    return mUtils.convertToDeviceOrientationFrom(lastRotationDetected)
+    // TODO: CHECK IF WE CAN INFER IT AT STARTUP TIME
+    return Orientation.UNKNOWN
   }
 
   private fun initIsLocked(): Boolean {
@@ -127,10 +114,9 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     ).contains(activity.requestedOrientation)
   }
 
-  private fun onOrientationChanged(rawDeviceOrientation: Int) {
-    val deviceOrientation = mUtils.convertToDeviceOrientationFrom(rawDeviceOrientation)
-
-    if (rawDeviceOrientation != ORIENTATION_UNKNOWN && deviceOrientation == Orientation.UNKNOWN) {
+  private fun onOrientationAnglesChanged(orientationAngles: FloatArray) {
+    val deviceOrientation = mUtils.convertToDeviceOrientationFrom(orientationAngles)
+    if (deviceOrientation == Orientation.UNKNOWN) {
       return;
     }
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -111,7 +111,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private fun onOrientationAnglesChanged(orientationAngles: FloatArray) {
     val deviceOrientation = mUtils.convertToDeviceOrientationFrom(orientationAngles)
     if (deviceOrientation == Orientation.UNKNOWN) {
-      return;
+      return
     }
 
     if (lastDeviceOrientation == deviceOrientation) {
@@ -133,7 +133,12 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
       return
     }
 
-    val newInterfaceOrientation = mUtils.convertToInterfaceOrientationFrom(deviceOrientation);
+    var newInterfaceOrientation = mUtils.convertToInterfaceOrientationFrom(deviceOrientation);
+    if (newInterfaceOrientation == Orientation.UNKNOWN) {
+      val rotation = mUtils.getInterfaceRotation()
+      newInterfaceOrientation = mUtils.convertToOrientationFromScreenRotation(rotation)
+    }
+
     if (newInterfaceOrientation == lastInterfaceOrientation) {
       return
     }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 class OrientationDirectorModuleImpl internal constructor(private val context: ReactApplicationContext) {
   private var mUtils = Utils(context)
   private var mEventManager = EventManager(context)
-  private var mSensorListener = SensorListener(context)
+  private var mOrientationSensorsEventListener = OrientationSensorsEventListener(context)
   private var mAutoRotationObserver = AutoRotationObserver(
     context, Handler(
       Looper.getMainLooper()
@@ -23,7 +23,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private var isLocked: Boolean = false
 
   init {
-    mSensorListener.setOnOrientationAnglesChangedCallback { orientation ->
+    mOrientationSensorsEventListener.setOnOrientationAnglesChangedCallback { orientation ->
       onOrientationAnglesChanged(orientation)
     }
 
@@ -31,17 +31,17 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
 
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
-      mSensorListener.enable()
+      mOrientationSensorsEventListener.enable()
       mAutoRotationObserver.enable()
     }
     mLifecycleListener.setOnHostPauseCallback {
       if (initialized) {
-        mSensorListener.disable()
+        mOrientationSensorsEventListener.disable()
         mAutoRotationObserver.disable()
       }
     }
     mLifecycleListener.setOnHostDestroyCallback {
-      mSensorListener.disable()
+      mOrientationSensorsEventListener.disable()
       mAutoRotationObserver.disable()
     }
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -28,20 +28,21 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
       onOrientationChanged(orientation)
     }
 
-    if (mSensorListener.canDetectOrientation()) {
-      mSensorListener.enable()
-    } else {
-      mSensorListener.disable()
-    }
+//    if (mSensorListener.canDetectOrientation()) {
+//      mSensorListener.enable()
+//    } else {
+//      mSensorListener.disable()
+//    }
 
     mAutoRotationObserver.enable()
 
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
-      if (mSensorListener.canDetectOrientation()) {
-        mSensorListener.enable()
-      }
+//      if (mSensorListener.canDetectOrientation()) {
+//        mSensorListener.enable()
+//      }
 
+      mSensorListener.enable()
       mAutoRotationObserver.enable()
     }
     mLifecycleListener.setOnHostPauseCallback {

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -134,6 +134,13 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     }
 
     var newInterfaceOrientation = mUtils.convertToInterfaceOrientationFrom(deviceOrientation);
+
+    /**
+     * When the device orientation is either face up or face down,
+     * we can't match it to an interface orientation, because
+     * it could be either portrait or any landscape.
+     * So we read it from the system itself.
+     */
     if (newInterfaceOrientation == Orientation.UNKNOWN) {
       val rotation = mUtils.getInterfaceRotation()
       newInterfaceOrientation = mUtils.convertToOrientationFromScreenRotation(rotation)

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -48,7 +48,6 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     initialSupportedInterfaceOrientations =
       context.currentActivity?.requestedOrientation ?: initialSupportedInterfaceOrientations
     lastInterfaceOrientation = initInterfaceOrientation()
-    lastDeviceOrientation = initDeviceOrientation()
     isLocked = initIsLocked()
 
     initialized = true
@@ -96,11 +95,6 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private fun initInterfaceOrientation(): Orientation {
     val rotation = mUtils.getInterfaceRotation()
     return mUtils.convertToOrientationFromScreenRotation(rotation)
-  }
-
-  private fun initDeviceOrientation(): Orientation {
-    // TODO: CHECK IF WE CAN INFER IT AT STARTUP TIME
-    return Orientation.UNKNOWN
   }
 
   private fun initIsLocked(): Boolean {

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -5,10 +5,9 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 
-class SensorListener(
+class OrientationSensorsEventListener(
   context: ReactApplicationContext,
 ) : SensorEventListener {
   private var mSensorManager: SensorManager

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -47,14 +47,16 @@ class OrientationSensorsEventListener(
       System.arraycopy(event.values, 0, magnetometerReading, 0, magnetometerReading.size)
     }
 
-    // TODO: IMPLEMENT FREE FALLING CHECK
     val rotationMatrix = FloatArray(9)
-    SensorManager.getRotationMatrix(
+    val didComputeMatrix = SensorManager.getRotationMatrix(
       rotationMatrix,
       null,
       accelerometerReading,
       magnetometerReading
     )
+    if (!didComputeMatrix) {
+      return
+    }
 
     val orientationAngles = FloatArray(3)
     SensorManager.getOrientation(rotationMatrix, orientationAngles)

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -10,27 +10,18 @@ import com.facebook.react.bridge.ReactApplicationContext
 class OrientationSensorsEventListener(
   context: ReactApplicationContext,
 ) : SensorEventListener {
-  private var mSensorManager: SensorManager
+  private var mSensorManager: SensorManager = context.getSystemService(SENSOR_SERVICE) as SensorManager
 
-  private var mAccelerometerSensor: Sensor?
-  private var mMagneticFieldSensor: Sensor?
+  private var mAccelerometerSensor: Sensor? = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+  private var mMagneticFieldSensor: Sensor? = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
 
-  private var hasRequiredSensors: Boolean
+  private var hasRequiredSensors: Boolean = mAccelerometerSensor != null && mMagneticFieldSensor != null
 
   private val accelerometerReading = FloatArray(3)
   private val magnetometerReading = FloatArray(3)
 
   private var lastComputedOrientationAngles = FloatArray(3)
   private var onOrientationAnglesChangedCallback: ((orientationAngles: FloatArray) -> Unit)? = null
-
-  init {
-    mSensorManager = context.getSystemService(SENSOR_SERVICE) as SensorManager;
-
-    mAccelerometerSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-    mMagneticFieldSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
-
-    hasRequiredSensors = mAccelerometerSensor != null && mMagneticFieldSensor != null
-  }
 
   fun setOnOrientationAnglesChangedCallback(callback: (orientation: FloatArray) -> Unit) {
     onOrientationAnglesChangedCallback = callback

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -19,6 +19,8 @@ class OrientationSensorsEventListener(
 
   private val accelerometerReading = FloatArray(3)
   private val magnetometerReading = FloatArray(3)
+
+  private var lastComputedOrientationAngles = FloatArray(3)
   private var onOrientationAnglesChangedCallback: ((orientationAngles: FloatArray) -> Unit)? = null
 
   init {
@@ -61,8 +63,12 @@ class OrientationSensorsEventListener(
     val orientationAngles = FloatArray(3)
     SensorManager.getOrientation(rotationMatrix, orientationAngles)
 
-    // TODO: FILTER DATA THAT BY EQUALITY
+    if (lastComputedOrientationAngles.contentEquals(orientationAngles)) {
+      return
+    }
+
     onOrientationAnglesChangedCallback?.invoke(orientationAngles)
+    lastComputedOrientationAngles = orientationAngles
   }
 
   override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -98,31 +98,32 @@ class SensorListener(
   }
 
   private fun calculateDeviceOrientation() {
-    val (azimuthRadians, pitchRadians, rollRadians) = orientationAngles;
+    val (_, pitchRadians, rollRadians) = orientationAngles;
 
-    val azimuthDegrees = Math.toDegrees(azimuthRadians.toDouble()).toFloat()
     val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
     val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
     val orientation = when {
       // Portrait (Rotation_0)
-      azimuthDegrees.equals(0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
+      pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Landscape Right (Rotation_90)
-      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
+      pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Portrait Upside Down (Rotation_180)
-      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(-0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
+      pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Landscape Left (Rotation_270)
-      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
+      pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       else -> "Unknown Orientation"
     }
+
+    Log.d(TAG, "orientation: $orientation")
   }
 
   companion object {

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -8,6 +8,7 @@ import android.hardware.SensorManager
 import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 import kotlin.math.PI
+import kotlin.math.abs
 
 class SensorListener(
   context: ReactApplicationContext,
@@ -62,27 +63,28 @@ class SensorListener(
 
     updateOrientationAngles()
 
-    val z = orientationAngles[0]
-    val x = orientationAngles[1]
-    val y = orientationAngles[2]
+    val (azimuthRadians, pitchRadians, rollRadians) = orientationAngles;
+
+    val azimuthDegrees = Math.toDegrees(azimuthRadians.toDouble()).toFloat()
+    val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
+    val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
     val orientation = when {
-
       // Portrait (Rotation_0)
-      x.equals(0f) && y.equals(-0f) && z.equals(0f) -> "Face Up"
-      x.equals(0f) && y.equals(-PI.toFloat()) && z.equals(PI.toFloat()) -> "Face Down"
+      azimuthDegrees.equals(0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Landscape Right (Rotation_90)
-      x.equals(-0f) && y.equals(-0f) && z.equals(PI.div(2).toFloat()) -> "Face Up"
-      x.equals(-0f) && y.equals(-PI.toFloat()) && z.equals(PI.div(2).toFloat()) -> "Face Down"
+      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Portrait Upside Down (Rotation_180)
-      x.equals(0f) && y.equals(-0f) && z.equals(PI.toFloat()) -> "Face Up"
-      x.equals(0f) && y.equals(-PI.toFloat()) && z.equals(-0f) -> "Face Down"
+      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(-0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       // Landscape Left (Rotation_270)
-      x.equals(-0f) && y.equals(-0f) && z.equals(-PI.div(2).toFloat()) -> "Face Up"
-      x.equals(-0f) && y.equals(-PI.toFloat()) && z.equals(-PI.div(2).toFloat()) -> "Face Down"
+      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
 
       else -> "Unknown Orientation"
     }

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -105,17 +105,11 @@ class SensorListener(
 
     val orientation = when {
       // Portrait (Rotation_0)
-      pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
-      pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
-
-      // Landscape Right (Rotation_90)
-      pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
-      pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
-
       // Portrait Upside Down (Rotation_180)
       pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
       pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
 
+      // Landscape Right (Rotation_90)
       // Landscape Left (Rotation_270)
       pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
       pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -1,15 +1,34 @@
 package com.orientationdirector.implementation
 
+import android.content.Context.SENSOR_SERVICE
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
 import android.hardware.SensorManager
-import android.view.OrientationEventListener
+import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 
 class SensorListener(
   context: ReactApplicationContext,
-) : OrientationEventListener(context, SensorManager.SENSOR_DELAY_UI) {
+) : SensorEventListener {
+  private var mSensorManager: SensorManager
+
+  private var mAccelerometerSensor: Sensor?
+  private var mMagneticFieldSensor: Sensor?
+
+  private var hasRequiredSensors: Boolean
 
   private var lastRotationDetected: Int? = null
   private var onOrientationChangedCallback: ((orientation: Int) -> Unit)? = null
+
+  init {
+    mSensorManager = context.getSystemService(SENSOR_SERVICE) as SensorManager;
+
+    mAccelerometerSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+    mMagneticFieldSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
+
+    hasRequiredSensors = mAccelerometerSensor != null && mMagneticFieldSensor != null
+  }
 
   fun getLastRotationDetected(): Int? {
     return lastRotationDetected
@@ -19,8 +38,43 @@ class SensorListener(
     onOrientationChangedCallback = callback
   }
 
-  override fun onOrientationChanged(orientation: Int) {
-    lastRotationDetected = orientation
-    onOrientationChangedCallback?.invoke(orientation)
+//  override fun onOrientationChanged(orientation: Int) {
+//    lastRotationDetected = orientation
+//    onOrientationChangedCallback?.invoke(orientation)
+//  }
+
+  override fun onSensorChanged(event: SensorEvent?) {
+    if (event == null) {
+      return
+    }
+
+//    Log.d(TAG, "onSensorChanged $event")
+  }
+
+  override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+    // TODO("Not yet implemented")
+  }
+
+  fun enable() {
+    Log.d(TAG, "enable - started")
+    if (!hasRequiredSensors) {
+      Log.d(TAG, "enable - device is missing required sensors")
+      return
+    }
+
+    mSensorManager.registerListener(this, mAccelerometerSensor, SensorManager.SENSOR_DELAY_NORMAL)
+    mSensorManager.registerListener(this, mMagneticFieldSensor, SensorManager.SENSOR_DELAY_NORMAL)
+
+    Log.d(TAG, "enable - done")
+  }
+
+  fun disable() {
+    Log.d(TAG, "disable - started")
+    mSensorManager.unregisterListener(this)
+    Log.d(TAG, "disable - done")
+  }
+
+  companion object {
+    private const val TAG = "SensorListener"
   }
 }

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -62,34 +62,7 @@ class SensorListener(
     }
 
     updateOrientationAngles()
-
-    val (azimuthRadians, pitchRadians, rollRadians) = orientationAngles;
-
-    val azimuthDegrees = Math.toDegrees(azimuthRadians.toDouble()).toFloat()
-    val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
-    val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
-
-    val orientation = when {
-      // Portrait (Rotation_0)
-      azimuthDegrees.equals(0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
-
-      // Landscape Right (Rotation_90)
-      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
-
-      // Portrait Upside Down (Rotation_180)
-      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(-0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
-
-      // Landscape Left (Rotation_270)
-      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
-      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
-
-      else -> "Unknown Orientation"
-    }
-
-    Log.d(TAG, orientation)
+    calculateDeviceOrientation()
   }
 
   override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
@@ -124,6 +97,36 @@ class SensorListener(
     )
 
     SensorManager.getOrientation(rotationMatrix, orientationAngles)
+  }
+
+  private fun calculateDeviceOrientation() {
+    val (azimuthRadians, pitchRadians, rollRadians) = orientationAngles;
+
+    val azimuthDegrees = Math.toDegrees(azimuthRadians.toDouble()).toFloat()
+    val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
+    val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
+
+    val orientation = when {
+      // Portrait (Rotation_0)
+      azimuthDegrees.equals(0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
+
+      // Landscape Right (Rotation_90)
+      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
+
+      // Portrait Upside Down (Rotation_180)
+      azimuthDegrees.equals(180f) && pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(-0f) && pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> "Face Down"
+
+      // Landscape Left (Rotation_270)
+      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> "Face Up"
+      azimuthDegrees.equals(-90f) && pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> "Face Down"
+
+      else -> "Unknown Orientation"
+    }
+
+    Log.d(TAG, orientation)
   }
 
   companion object {

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -7,6 +7,7 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
+import kotlin.math.PI
 
 class SensorListener(
   context: ReactApplicationContext,
@@ -17,6 +18,11 @@ class SensorListener(
   private var mMagneticFieldSensor: Sensor?
 
   private var hasRequiredSensors: Boolean
+
+  private val accelerometerReading = FloatArray(3)
+  private val magnetometerReading = FloatArray(3)
+  private val rotationMatrix = FloatArray(9)
+  private val orientationAngles = FloatArray(3)
 
   private var lastRotationDetected: Int? = null
   private var onOrientationChangedCallback: ((orientation: Int) -> Unit)? = null
@@ -48,7 +54,40 @@ class SensorListener(
       return
     }
 
-//    Log.d(TAG, "onSensorChanged $event")
+    if (event.sensor.type == Sensor.TYPE_ACCELEROMETER) {
+      System.arraycopy(event.values, 0, accelerometerReading, 0, accelerometerReading.size)
+    } else if (event.sensor.type == Sensor.TYPE_MAGNETIC_FIELD) {
+      System.arraycopy(event.values, 0, magnetometerReading, 0, magnetometerReading.size)
+    }
+
+    updateOrientationAngles()
+
+    val z = orientationAngles[0]
+    val x = orientationAngles[1]
+    val y = orientationAngles[2]
+
+    val orientation = when {
+
+      // Portrait (Rotation_0)
+      x.equals(0f) && y.equals(-0f) && z.equals(0f) -> "Face Up"
+      x.equals(0f) && y.equals(-PI.toFloat()) && z.equals(PI.toFloat()) -> "Face Down"
+
+      // Landscape Right (Rotation_90)
+      x.equals(-0f) && y.equals(-0f) && z.equals(PI.div(2).toFloat()) -> "Face Up"
+      x.equals(-0f) && y.equals(-PI.toFloat()) && z.equals(PI.div(2).toFloat()) -> "Face Down"
+
+      // Portrait Upside Down (Rotation_180)
+      x.equals(0f) && y.equals(-0f) && z.equals(PI.toFloat()) -> "Face Up"
+      x.equals(0f) && y.equals(-PI.toFloat()) && z.equals(-0f) -> "Face Down"
+
+      // Landscape Left (Rotation_270)
+      x.equals(-0f) && y.equals(-0f) && z.equals(-PI.div(2).toFloat()) -> "Face Up"
+      x.equals(-0f) && y.equals(-PI.toFloat()) && z.equals(-PI.div(2).toFloat()) -> "Face Down"
+
+      else -> "Unknown Orientation"
+    }
+
+    Log.d(TAG, orientation)
   }
 
   override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
@@ -72,6 +111,17 @@ class SensorListener(
     Log.d(TAG, "disable - started")
     mSensorManager.unregisterListener(this)
     Log.d(TAG, "disable - done")
+  }
+
+  private fun updateOrientationAngles() {
+    SensorManager.getRotationMatrix(
+      rotationMatrix,
+      null,
+      accelerometerReading,
+      magnetometerReading
+    )
+
+    SensorManager.getOrientation(rotationMatrix, orientationAngles)
   }
 
   companion object {

--- a/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/SensorListener.kt
@@ -7,8 +7,6 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
-import kotlin.math.PI
-import kotlin.math.abs
 
 class SensorListener(
   context: ReactApplicationContext,
@@ -125,8 +123,6 @@ class SensorListener(
 
       else -> "Unknown Orientation"
     }
-
-    Log.d(TAG, orientation)
   }
 
   companion object {

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -51,17 +51,17 @@ class Utils(private val context: ReactContext) {
     // These limits are set based on SensorManager.getOrientation reference
     // https://developer.android.com/develop/sensors-and-location/sensors/sensors_position#sensors-pos-orient
     //
-    val portraitUpsideDownLimit = 90f
+    val portraitLimit = -90f
     val landscapeRightLimit = 180f
     val landscapeLeftLimit = -180f
     //
     //////////////////////////////////////
 
     return when {
-      rollDegrees in tolerance..landscapeRightLimit -> Orientation.LANDSCAPE_RIGHT
-      rollDegrees in landscapeLeftLimit..-tolerance -> Orientation.LANDSCAPE_LEFT
-      pitchDegrees in 0f .. portraitUpsideDownLimit -> Orientation.PORTRAIT_UPSIDE_DOWN
-      else -> Orientation.PORTRAIT // -> portraitLimit = -90f .. -0f
+      rollDegrees in tolerance..landscapeRightLimit - tolerance -> Orientation.LANDSCAPE_RIGHT
+      rollDegrees in landscapeLeftLimit + tolerance..-tolerance -> Orientation.LANDSCAPE_LEFT
+      pitchDegrees in portraitLimit .. -0f -> Orientation.PORTRAIT
+      else -> Orientation.PORTRAIT_UPSIDE_DOWN
     }
   }
 

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -3,7 +3,6 @@ package com.orientationdirector.implementation
 import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Build
-import android.util.Log
 import android.view.Surface
 import android.view.WindowManager
 import com.facebook.react.bridge.ReactContext
@@ -26,24 +25,6 @@ class Utils(private val context: ReactContext) {
     val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
     val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
-    // First check if device is flat facing up or down
-    val orientation = when {
-      // Portrait (Rotation_0)
-      // Portrait Upside Down (Rotation_180)
-      pitchDegrees.equals(0f) && rollDegrees.equals(-0f) -> Orientation.FACE_UP
-      pitchDegrees.equals(0f) && rollDegrees.equals(-180f) -> Orientation.FACE_DOWN
-
-      // Landscape Right (Rotation_90)
-      // Landscape Left (Rotation_270)
-      pitchDegrees.equals(-0f) && rollDegrees.equals(-0f) -> Orientation.FACE_UP
-      pitchDegrees.equals(-0f) && rollDegrees.equals(-180f) -> Orientation.FACE_DOWN
-
-      else -> Orientation.UNKNOWN
-    }
-    if (orientation != Orientation.UNKNOWN) {
-      return orientation
-    }
-
     // Needed to account for tilting
     val tolerance = 20f
 
@@ -58,9 +39,11 @@ class Utils(private val context: ReactContext) {
     //////////////////////////////////////
 
     return when {
+      rollDegrees.equals(-0f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_UP
+      rollDegrees.equals(-180f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_DOWN
       rollDegrees in tolerance..landscapeRightLimit - tolerance -> Orientation.LANDSCAPE_RIGHT
       rollDegrees in landscapeLeftLimit + tolerance..-tolerance -> Orientation.LANDSCAPE_LEFT
-      pitchDegrees in portraitLimit .. -0f -> Orientation.PORTRAIT
+      pitchDegrees in portraitLimit..-0f -> Orientation.PORTRAIT
       else -> Orientation.PORTRAIT_UPSIDE_DOWN
     }
   }
@@ -84,7 +67,7 @@ class Utils(private val context: ReactContext) {
   }
 
   fun convertToOrientationFromScreenRotation(screenRotation: Int): Orientation {
-    return when(screenRotation) {
+    return when (screenRotation) {
       Surface.ROTATION_270 -> Orientation.LANDSCAPE_RIGHT
       Surface.ROTATION_90 -> Orientation.LANDSCAPE_LEFT
       Surface.ROTATION_180 -> Orientation.PORTRAIT_UPSIDE_DOWN
@@ -93,7 +76,7 @@ class Utils(private val context: ReactContext) {
   }
 
   fun convertToInterfaceOrientationFrom(deviceOrientation: Orientation): Orientation {
-    return when(deviceOrientation) {
+    return when (deviceOrientation) {
       Orientation.PORTRAIT -> Orientation.PORTRAIT
       Orientation.LANDSCAPE_RIGHT -> Orientation.LANDSCAPE_LEFT
       Orientation.PORTRAIT_UPSIDE_DOWN -> Orientation.PORTRAIT_UPSIDE_DOWN

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -25,7 +25,7 @@ class Utils(private val context: ReactContext) {
     val pitchDegrees = Math.toDegrees(pitchRadians.toDouble()).toFloat()
     val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
-    // Needed to account for tilting
+    // This is needed to account for inaccuracy due to subtle movements such as tilting
     val tolerance = 20f
 
     //////////////////////////////////////

--- a/src/types/Orientation.enum.ts
+++ b/src/types/Orientation.enum.ts
@@ -4,8 +4,6 @@ export enum Orientation {
   landscapeRight = 2,
   portraitUpsideDown = 3,
   landscapeLeft = 4,
-
-  // iOS only
   faceUp = 5,
   faceDown = 6,
 }


### PR DESCRIPTION
This PR implements a new device orientation setup that aligns with iOS through the [Android Sensor Framework](https://developer.android.com/develop/sensors-and-location/sensors/sensors_overview).

We've dropped the **OrientationEventListener** implementation in favour of a **SensorEventListener** that leverages both accelerometer and magnetometer sensors.
Their readings are then handled by the `SensorManager.getRotationMatrix` and `SensorManager.getOrientation` methods to obtain useful orientation angles that we can use to compute the device orientation at runtime.