### PR TITLE
feat(android): enable and disable sensors based on usage

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -21,6 +21,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private var lastDeviceOrientation = Orientation.UNKNOWN
   private var initialized = false
   private var isLocked: Boolean = false
+  private var shouldEnableOrientationSensorsEventListener = false;
   private var didComputeInitialDeviceOrientation = false;
 
   init {
@@ -32,7 +33,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
 
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
-      if (!didComputeInitialDeviceOrientation) {
+      if (!didComputeInitialDeviceOrientation || shouldEnableOrientationSensorsEventListener) {
         mOrientationSensorsEventListener.enable()
       }
       mAutoRotationObserver.enable()
@@ -96,10 +97,12 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   }
 
   fun enableOrientationSensors() {
+    shouldEnableOrientationSensorsEventListener = true
     mOrientationSensorsEventListener.enable()
   }
 
   fun disableOrientationSensor() {
+    shouldEnableOrientationSensorsEventListener = false
     mOrientationSensorsEventListener.disable()
   }
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -39,14 +39,16 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
       mAutoRotationObserver.enable()
     }
     mLifecycleListener.setOnHostPauseCallback {
-      if (initialized) {
+      if (initialized && shouldEnableOrientationSensorsEventListener) {
         mOrientationSensorsEventListener.disable()
         mAutoRotationObserver.disable()
       }
     }
     mLifecycleListener.setOnHostDestroyCallback {
-      mOrientationSensorsEventListener.disable()
-      mAutoRotationObserver.disable()
+      if (shouldEnableOrientationSensorsEventListener) {
+        mOrientationSensorsEventListener.disable()
+        mAutoRotationObserver.disable()
+      }
     }
 
     initialSupportedInterfaceOrientations =

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -21,6 +21,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
   private var lastDeviceOrientation = Orientation.UNKNOWN
   private var initialized = false
   private var isLocked: Boolean = false
+  private var didComputeInitialDeviceOrientation = false;
 
   init {
     mOrientationSensorsEventListener.setOnOrientationAnglesChangedCallback { orientation ->
@@ -31,7 +32,9 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
 
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
-      mOrientationSensorsEventListener.enable()
+      if (!didComputeInitialDeviceOrientation) {
+        mOrientationSensorsEventListener.enable()
+      }
       mAutoRotationObserver.enable()
     }
     mLifecycleListener.setOnHostPauseCallback {
@@ -130,6 +133,11 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     lastDeviceOrientation = deviceOrientation
 
     adaptInterfaceTo(deviceOrientation)
+
+    if (!didComputeInitialDeviceOrientation) {
+      didComputeInitialDeviceOrientation = true
+      mOrientationSensorsEventListener.disable()
+    }
   }
 
   private fun adaptInterfaceTo(deviceOrientation: Orientation) {

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -92,6 +92,14 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     updateLastInterfaceOrientationTo(initInterfaceOrientation())
   }
 
+  fun enableOrientationSensors() {
+    mOrientationSensorsEventListener.enable()
+  }
+
+  fun disableOrientationSensor() {
+    mOrientationSensorsEventListener.disable()
+  }
+
   private fun initInterfaceOrientation(): Orientation {
     val rotation = mUtils.getInterfaceRotation()
     return mUtils.convertToOrientationFromScreenRotation(rotation)

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -76,8 +76,4 @@ class OrientationSensorsEventListener(
   fun disable() {
     mSensorManager.unregisterListener(this)
   }
-
-  companion object {
-    private const val TAG = "SensorListener"
-  }
 }

--- a/android/src/newarch/OrientationDirectorModule.kt
+++ b/android/src/newarch/OrientationDirectorModule.kt
@@ -44,6 +44,14 @@ class OrientationDirectorModule internal constructor(context: ReactApplicationCo
     return implementation.getIsAutoRotationEnabled()
   }
 
+  override fun enableOrientationSensors() {
+    return implementation.enableOrientationSensors()
+  }
+
+  override fun disableOrientationSensors() {
+    return implementation.disableOrientationSensor()
+  }
+
   override fun addListener(eventName: String) {}
 
   override fun removeListeners(count: Double) {}

--- a/android/src/oldarch/OrientationDirectorModule.kt
+++ b/android/src/oldarch/OrientationDirectorModule.kt
@@ -49,6 +49,16 @@ class OrientationDirectorModule internal constructor(context: ReactApplicationCo
   }
 
   @ReactMethod()
+  fun enableOrientationSensors() {
+    return implementation.enableOrientationSensors()
+  }
+
+  @ReactMethod()
+  fun disableOrientationSensors() {
+    return implementation.disableOrientationSensors()
+  }
+
+  @ReactMethod()
   fun addListener(eventName: String) {}
 
   @ReactMethod()

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -21,7 +21,7 @@ class EventEmitter {
       Event.DeviceOrientationDidChange
     );
 
-    if (listenerCount === 0) {
+    if (listenerCount === 1) {
       Module.enableOrientationSensors();
     }
 

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -17,7 +17,13 @@ class EventEmitter {
       return listener;
     }
 
-    Module.enableOrientationSensors();
+    const listenerCount = ModuleEventEmitter.listenerCount(
+      Event.DeviceOrientationDidChange
+    );
+
+    if (listenerCount === 0) {
+      Module.enableOrientationSensors();
+    }
 
     return EventEmitter.createDeviceOrientationListenerProxy(listener);
   }

--- a/src/EventEmitter.ts
+++ b/src/EventEmitter.ts
@@ -1,0 +1,61 @@
+import { Platform, type EmitterSubscription } from 'react-native';
+import Module, { ModuleEventEmitter } from './module';
+import Event from './types/Event.enum';
+import type { OrientationEvent } from './types/OrientationEvent.interface';
+import type { LockedEvent } from './types/LockedEvent.interface';
+
+class EventEmitter {
+  static addDeviceOrientationDidChangeListener(
+    callback: (orientation: OrientationEvent) => void
+  ) {
+    let listener = ModuleEventEmitter.addListener(
+      Event.DeviceOrientationDidChange,
+      callback
+    );
+
+    if (Platform.OS !== 'android') {
+      return listener;
+    }
+
+    Module.enableOrientationSensors();
+
+    return EventEmitter.createDeviceOrientationListenerProxy(listener);
+  }
+
+  static addInterfaceOrientationDidChangeListener(
+    callback: (orientation: OrientationEvent) => void
+  ) {
+    return ModuleEventEmitter.addListener(
+      Event.InterfaceOrientationDidChange,
+      callback
+    );
+  }
+
+  static addLockDidChangeListener(callback: (event: LockedEvent) => void) {
+    return ModuleEventEmitter.addListener(Event.LockDidChange, callback);
+  }
+
+  private static createDeviceOrientationListenerProxy(
+    listener: EmitterSubscription
+  ) {
+    return new Proxy(listener, {
+      get(target, propertyKey, receiver) {
+        if (propertyKey !== 'remove') {
+          return Reflect.get(target, propertyKey, receiver);
+        }
+
+        const listenerCount = ModuleEventEmitter.listenerCount(
+          Event.DeviceOrientationDidChange
+        );
+
+        if (listenerCount === 1) {
+          Module.disableOrientationSensors();
+        }
+
+        return Reflect.get(target, propertyKey, receiver);
+      },
+    });
+  }
+}
+
+export default EventEmitter;

--- a/src/NativeOrientationDirector.ts
+++ b/src/NativeOrientationDirector.ts
@@ -7,8 +7,19 @@ export interface Spec extends TurboModule {
   lockTo(orientation: number): void;
   unlock(): void;
   isLocked(): boolean;
-  isAutoRotationEnabled(): boolean;
   resetSupportedInterfaceOrientations(): void;
+
+  ////////////////////////////////////
+  //
+  // ANDROID ONLY
+  //
+
+  isAutoRotationEnabled(): boolean;
+  enableOrientationSensors(): void;
+  disableOrientationSensors(): void;
+
+  //
+  ////////////////////////////////////
 
   addListener: (eventType: string) => void;
   removeListeners: (count: number) => void;

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -84,16 +84,18 @@ class RNOrientationDirector {
 
     const listenerProxy = new Proxy(listener, {
       get(target, propertyKey, receiver) {
-        if (propertyKey === 'remove') {
-          const listenerCount = EventEmitter.listenerCount(
-            Event.DeviceOrientationDidChange
-          );
-
-          if (listenerCount === 1) {
-            console.log('Disable sensors');
-            Module.disableOrientationSensors();
-          }
+        if (propertyKey !== 'remove') {
+          return Reflect.get(target, propertyKey, receiver);
         }
+
+        const listenerCount = EventEmitter.listenerCount(
+          Event.DeviceOrientationDidChange
+        );
+
+        if (listenerCount === 1) {
+          Module.disableOrientationSensors();
+        }
+
         return Reflect.get(target, propertyKey, receiver);
       },
     });

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -85,8 +85,14 @@ class RNOrientationDirector {
     const listenerProxy = new Proxy(listener, {
       get(target, propertyKey, receiver) {
         if (propertyKey === 'remove') {
-          console.log('Disabling sensors');
-          Module.disableOrientationSensors();
+          const listenerCount = EventEmitter.listenerCount(
+            Event.DeviceOrientationDidChange
+          );
+
+          if (listenerCount === 1) {
+            console.log('Disable sensors');
+            Module.disableOrientationSensors();
+          }
         }
         return Reflect.get(target, propertyKey, receiver);
       },

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
-import Module, { EventEmitter } from './module';
-import Event from './types/Event.enum';
+import Module from './module';
 import type { HumanReadableOrientationsResource } from './types/HumanReadableOrientationsResource.type';
 import { Orientation } from './types/Orientation.enum';
 import { AutoRotation } from './types/AutoRotation.enum';
@@ -8,6 +7,7 @@ import type { OrientationEvent } from './types/OrientationEvent.interface';
 import type { LockableOrientation } from './types/LockableOrientation.type';
 import type { LockedEvent } from './types/LockedEvent.interface';
 import type { HumanReadableAutoRotationsResource } from './types/HumanReadableAutoRotationsResource.type';
+import EventEmitter from './EventEmitter';
 
 class RNOrientationDirector {
   private static _humanReadableOrientationsResource: HumanReadableOrientationsResource =
@@ -72,48 +72,17 @@ class RNOrientationDirector {
   static listenForDeviceOrientationChanges(
     callback: (orientation: OrientationEvent) => void
   ) {
-    let listener = EventEmitter.addListener(
-      Event.DeviceOrientationDidChange,
-      callback
-    );
-    if (Platform.OS !== 'android') {
-      return listener;
-    }
-
-    Module.enableOrientationSensors();
-
-    const listenerProxy = new Proxy(listener, {
-      get(target, propertyKey, receiver) {
-        if (propertyKey !== 'remove') {
-          return Reflect.get(target, propertyKey, receiver);
-        }
-
-        const listenerCount = EventEmitter.listenerCount(
-          Event.DeviceOrientationDidChange
-        );
-
-        if (listenerCount === 1) {
-          Module.disableOrientationSensors();
-        }
-
-        return Reflect.get(target, propertyKey, receiver);
-      },
-    });
-
-    return listenerProxy;
+    return EventEmitter.addDeviceOrientationDidChangeListener(callback);
   }
 
   static listenForInterfaceOrientationChanges(
     callback: (orientation: OrientationEvent) => void
   ) {
-    return EventEmitter.addListener(
-      Event.InterfaceOrientationDidChange,
-      callback
-    );
+    return EventEmitter.addInterfaceOrientationDidChangeListener(callback);
   }
 
-  static listenForLockChanges(callback: (orientation: LockedEvent) => void) {
-    return EventEmitter.addListener(Event.LockDidChange, callback);
+  static listenForLockChanges(callback: (event: LockedEvent) => void) {
+    return EventEmitter.addLockDidChangeListener(callback);
   }
 
   static convertOrientationToHumanReadableString(orientation: Orientation) {

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -96,10 +96,6 @@ class RNOrientationDirector {
       autoRotation
     ];
   }
-
-  static disableOrientationSensors() {
-    return Module.disableOrientationSensors();
-  }
 }
 
 export default RNOrientationDirector;

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,6 +25,6 @@ const OrientationDirectorModule = Module
       }
     );
 
-export const EventEmitter = new NativeEventEmitter(Module);
+export const ModuleEventEmitter = new NativeEventEmitter(Module);
 
 export default OrientationDirectorModule as Spec;


### PR DESCRIPTION
This PR updates the android native setup and javascript public API to enable sensors based on the following conditions:

1. Enable orientation sensors at startup to compute initial device orientation and disable it right after;
2. Enable orientation sensors when there is at least one listener active;
3. Disable orientation sensors when there are no more listener active;

Doing so allows us to follow Google [sensors's best practices](https://developer.android.com/develop/sensors-and-location/sensors/sensors_overview#sensors-practices).