### PR TITLE
feat(js): extend lockTo method with additional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ In addition, the library exposes the following hooks:
 | [useDeviceOrientation](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useDeviceOrientation.hook.ts)                       | Returns the current device orientation and listens to changes           |
 | [useIsInterfaceOrientationLocked](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useIsInterfaceOrientationLocked.hook.ts) | Returns the current interface orientation status and listens to changes |
 
+Head over to the [example project](example) to see how to use the library.
+
 ### Warning
 
 Please be aware that there is a subtle difference between the device orientation
@@ -112,7 +114,12 @@ To match developers expectations, if you supply a device orientation and
 OrientationType.device, lockTo switches landscapeRight with left and vice versa
 to property align the interface orientation.
 
-Head over to the [example project](example) to see how to use the library.
+This behavior comes from the native API, you can find more information in their
+documentation:
+
+1. [iOS - UIInterfaceOrientation](https://developer.apple.com/documentation/uikit/uiinterfaceorientation)
+2. [iOS - UIDeviceOrientation](https://developer.apple.com/documentation/uikit/uideviceorientation)
+3. [Android - getRotation](<https://developer.android.com/reference/android/view/Display#getRotation()>)
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ In addition, the library exposes the following hooks:
 | [useDeviceOrientation](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useDeviceOrientation.hook.ts)                       | Returns the current device orientation and listens to changes           |
 | [useIsInterfaceOrientationLocked](https://github.com/gladiuscode/react-native-orientation-director/blob/main/src/hooks/useIsInterfaceOrientationLocked.hook.ts) | Returns the current interface orientation status and listens to changes |
 
+### Warning
+
+Please be aware that there is a subtle difference between the device orientation
+and the interface orientation.
+
+When you device is either in landscape left or right orientation, your interface
+is inverted, this is why lockTo method needs a second parameter to discriminate
+which type of orientation your are supplying.
+
+To match developers expectations, if you supply a device orientation and
+OrientationType.device, lockTo switches landscapeRight with left and vice versa
+to property align the interface orientation.
+
 Head over to the [example project](example) to see how to use the library.
 
 ### Android

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -3,6 +3,7 @@ import Module from './module';
 import type { HumanReadableOrientationsResource } from './types/HumanReadableOrientationsResource.type';
 import { Orientation } from './types/Orientation.enum';
 import { AutoRotation } from './types/AutoRotation.enum';
+import { OrientationType } from './types/OrientationType.enum';
 import type { OrientationEvent } from './types/OrientationEvent.interface';
 import type { LockableOrientation } from './types/LockableOrientation.type';
 import type { LockedEvent } from './types/LockedEvent.interface';
@@ -44,7 +45,43 @@ class RNOrientationDirector {
     return Module.getDeviceOrientation();
   }
 
-  static lockTo(orientation: LockableOrientation) {
+  /**
+   * Please be aware that device orientation is not the
+   * same as interface orientation.
+   *
+   * Specifically, landscape left and right are inverted:
+   *
+   * - landscapeLeft in device orientation is landscapeRight in interface orientation
+   * - landscapeRight in device orientation is landscapeLeft in interface orientation
+   *
+   * This is a behavior of the native API.
+   *
+   * When you pass an orientation value, do provide orientationType
+   * as well if the orientation value is not an interface orientation.
+   * Example: when using listenForDeviceOrientationChanges.
+   *
+   * @param orientation any lockable orientation enum value
+   * @param orientationType any orientation type enum value
+   */
+  static lockTo(
+    orientation: LockableOrientation,
+    orientationType: OrientationType = OrientationType.interface
+  ) {
+    if (orientationType === OrientationType.interface) {
+      Module.lockTo(orientation);
+      return;
+    }
+
+    if (orientation === Orientation.landscapeLeft) {
+      Module.lockTo(Orientation.landscapeRight);
+      return;
+    }
+
+    if (orientation === Orientation.landscapeRight) {
+      Module.lockTo(Orientation.landscapeLeft);
+      return;
+    }
+
     Module.lockTo(orientation);
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 export { Orientation } from './types/Orientation.enum';
 export { AutoRotation } from './types/AutoRotation.enum';
+export { OrientationType } from './types/OrientationType.enum';
 
 import useDeviceOrientation from './hooks/useDeviceOrientation.hook';
 export { useDeviceOrientation };

--- a/src/types/OrientationType.enum.ts
+++ b/src/types/OrientationType.enum.ts
@@ -1,0 +1,4 @@
+export enum OrientationType {
+  device = 'device',
+  interface = 'interface',
+}


### PR DESCRIPTION
This PR aims to improve lockTo method usability by:

1. Document that there is a difference between device orientation and interface orientation;
2. Provide a second parameter that discriminate the type of orientation value provided;

This is necessary because when we supply an orientation value that isn't explicit, for example when using listeners, if such value is either landscapeRight or landscapeLeft and tied to the device orientation, we need to switch them to match the interface orientation expectation. 