### PR TITLE
refactor(iOS): remove manual interface orientation computation

### DIFF
--- a/ios/implementation/OrientationDirectorImpl.swift
+++ b/ios/implementation/OrientationDirectorImpl.swift
@@ -104,10 +104,8 @@ import UIKit
         return supportedInterfaceOrientations.reduce(UIInterfaceOrientationMask()) { $0.union($1) }
     }
 
-    // TODO: FIX BECAUSE IT ALWAYS RETURNS PORTRAIT AND ITS BROKEN
     private func initInterfaceOrientation() -> Orientation {
-        let interfaceOrientation = utils.getInterfaceOrientation()
-        return utils.convertToOrientationFrom(uiInterfaceOrientation: interfaceOrientation)
+        return self.getOrientationFromInterface()
     }
 
     private func initDeviceOrientation() -> Orientation {
@@ -163,18 +161,8 @@ import UIKit
         if (deviceOrientation == Orientation.FACE_UP || deviceOrientation == Orientation.FACE_DOWN) {
             return
         }
-
-        let newInterfaceOrientationMask = utils.convertToMaskFrom(deviceOrientation: deviceOrientation)
-        let isSupported = self.supportedInterfaceOrientations.contains(newInterfaceOrientationMask)
-        if (!isSupported) {
-            return
-        }
-
-        let newInterfaceOrientation = utils.convertToOrientationFrom(mask: newInterfaceOrientationMask)
-        if (newInterfaceOrientation == lastInterfaceOrientation) {
-            return
-        }
-
+        
+        let newInterfaceOrientation = self.getOrientationFromInterface()
         updateLastInterfaceOrientationTo(value: newInterfaceOrientation)
     }
 
@@ -186,5 +174,10 @@ import UIKit
     private func updateLastInterfaceOrientationTo(value: Orientation) {
         self.eventManager.sendInterfaceOrientationDidChange(orientationValue: value.rawValue)
         lastInterfaceOrientation = value
+    }
+    
+    private func getOrientationFromInterface() -> Orientation {
+        let interfaceOrientation = utils.getInterfaceOrientation()
+        return utils.convertToOrientationFrom(uiInterfaceOrientation: interfaceOrientation)
     }
 }

--- a/ios/implementation/Utils.swift
+++ b/ios/implementation/Utils.swift
@@ -55,19 +55,6 @@ class Utils {
         }
     }
 
-    public func convertToOrientationFrom(mask: UIInterfaceOrientationMask) -> Orientation {
-        switch(mask) {
-        case .portraitUpsideDown:
-            return .PORTRAIT_UPSIDE_DOWN
-        case .landscapeRight:
-            return .LANDSCAPE_RIGHT
-        case .landscapeLeft:
-            return .LANDSCAPE_LEFT
-        default:
-            return .PORTRAIT
-        }
-    }
-
     /**
      Note: .portraitUpsideDown only works for devices with home button and iPads
      https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations
@@ -82,25 +69,6 @@ class Utils {
             return .portraitUpsideDown
         case .LANDSCAPE_LEFT:
             return .landscapeLeft
-        default:
-            return .all
-        }
-    }
-
-    /**
-     Note: .portraitUpsideDown only works for devices with home button and iPads
-     https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations
-     */
-    public func convertToMaskFrom(deviceOrientation: Orientation) -> UIInterfaceOrientationMask {
-        switch(deviceOrientation) {
-        case .PORTRAIT:
-            return .portrait
-        case .LANDSCAPE_RIGHT:
-            return .landscapeLeft
-        case .PORTRAIT_UPSIDE_DOWN:
-            return .portraitUpsideDown
-        case .LANDSCAPE_LEFT:
-            return .landscapeRight
         default:
             return .all
         }


### PR DESCRIPTION
This PR removes manual interface orientation computation on device orientation changes.
It switches it for the built in native API.