### PR TITLE
feat(js): add is lockable orientation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This library exports a class called: [RNOrientationDirector](https://github.com/
 | setHumanReadableOrientations             | Sets the mapping needed to convert orientation values to human readable strings   |
 | setHumanReadableAutoRotations            | Sets the mapping needed to convert auto rotation values to human readable strings |
 | resetSupportedInterfaceOrientations      | Resets the supported interface orientations to settings                           |
+| isLockableOrientation                    | Determines if orientation is lockable                                             |
 
 In addition, the library exposes the following hooks:
 

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -96,6 +96,16 @@ class RNOrientationDirector {
       autoRotation
     ];
   }
+
+  static isLockableOrientation(
+    orientation: Orientation
+  ): orientation is LockableOrientation {
+    return !(
+      orientation === Orientation.unknown ||
+      orientation === Orientation.faceUp ||
+      orientation === Orientation.faceDown
+    );
+  }
 }
 
 export default RNOrientationDirector;

--- a/src/RNOrientationDirector.ts
+++ b/src/RNOrientationDirector.ts
@@ -97,6 +97,21 @@ class RNOrientationDirector {
     ];
   }
 
+  /**
+   * This method checks if the given orientation is lockable
+   * by interface perspective.
+   *
+   * All orientations are lockable except for unknown, faceUp
+   * and faceDown.
+   *
+   * This method is useful when you want to lock the interface
+   * orientation from a given device orientation.
+   *
+   * Example: with listenForDeviceOrientationChanges
+   *
+   * @param orientation any orientation enum value
+   * @returns true if the orientation is lockable
+   */
   static isLockableOrientation(
     orientation: Orientation
   ): orientation is LockableOrientation {


### PR DESCRIPTION
This PR adds a new method to the public API: `isLockableOrientation`.

This method can be used with listenToDeviceOrientation, for example, to properly check if a given orientation can be used with lockTo, since we can't lock interface orientation to face up, face down or unknown.