### PR TITLE
fix(android): failing test

### DIFF
--- a/android/src/test/java/com/orientationdirector/implementation/OrientationDirectorModuleImplTest.kt
+++ b/android/src/test/java/com/orientationdirector/implementation/OrientationDirectorModuleImplTest.kt
@@ -149,8 +149,8 @@ class OrientationDirectorModuleImplTest {
     mModule.lockTo(5)
 
     assertEquals(
-      "When the interface is locked to landscape, getInterfaceOrientation should return landscape",
-      Orientation.LANDSCAPE,
+      "When the interface is locked to landscape, getInterfaceOrientation should return landscape right",
+      Orientation.LANDSCAPE_RIGHT,
       mModule.getInterfaceOrientation()
     )
   }


### PR DESCRIPTION
This PR fixes the latest test introduced for the lockTo enhancement: **assert_interface_orientation_matches_locked_to_landscape**