### PR TITLE
ci: improve pr workflow to run only on pr review approved

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,11 +1,6 @@
-name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+name: PR Validation
+
+on: workflow_dispatch
 
 jobs:
   lint:


### PR DESCRIPTION
This PR updates the pr workflow to run only on review submission with approved status.