### PR TITLE
fix(android): interface orientation listener not working with manual rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,40 @@ This way, Expo will handle the native setup for you during `prebuild`.
 
 ## Setup
 
+### Android
+
+This library uses a custom broadcast receiver to handle the manual orientation changes: when the user disables the
+autorotation feature and the system prompts the user to rotate the device, the library will listen to the broadcast
+sent by the MainActivity and update the interface orientation accordingly.
+
+To allow the library to listen to the broadcast, you need to override the `onConfigurationChanged` method in your
+MainActivity file, as shown below:
+
+```kotlin
+override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    val orientationDirectorCustomAction =
+      "${packageName}.${ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION}"
+
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
+
+    this.sendBroadcast(intent)
+}
+```
+
+Nothing else is required for Android.
+
+### iOS
+
 To properly handle interface orientation changes in iOS, you need to update your AppDelegate file. Since React Native
 0.77, the AppDelegate has been migrated to Swift, so see the instructions below for both Swift and Objective-C.
 
-### Objective-C
+#### Objective-C
 
 In your AppDelegate.h file, import "OrientationDirector.h" and implement supportedInterfaceOrientationsForWindow method as follows:
 
@@ -82,7 +112,7 @@ In your AppDelegate.h file, import "OrientationDirector.h" and implement support
 }
 ```
 
-### Swift
+#### Swift
 
 You need to create a [bridging header](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift#Import-Code-Within-an-App-Target)
 to import the library, as shown below:
@@ -100,8 +130,6 @@ override func application(_ application: UIApplication, supportedInterfaceOrient
 ```
 
 If you need help, you can check the example project.
-
-There is no need to do anything in Android, it works out of the box.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Then, you need to add the plugin to your app.json file:
 
 This way, Expo will handle the native setup for you during `prebuild`.
 
+> Note: only SDK 50 and above are supported, the plugin is configured to handle only the kotlin template.
+
 ## Setup
 
 ### Android

--- a/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
@@ -33,7 +33,7 @@ class ConfigurationChangedBroadcastReceiver internal constructor(private val con
    * flag.
    */
   fun register() {
-    val filter = IntentFilter("${context.packageName}.CONFIGURATION_CHANGED")
+    val filter = IntentFilter("${context.packageName}.$CUSTOM_INTENT_ACTION")
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       context.registerReceiver(this, filter, Context.RECEIVER_NOT_EXPORTED)
@@ -44,5 +44,9 @@ class ConfigurationChangedBroadcastReceiver internal constructor(private val con
 
   fun unregister() {
     context.unregisterReceiver(this)
+  }
+
+  companion object {
+    const val CUSTOM_INTENT_ACTION = "CONFIGURATION_CHANGED"
   }
 }

--- a/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
@@ -1,0 +1,36 @@
+package com.orientationdirector.implementation
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import com.facebook.react.bridge.ReactApplicationContext
+
+class ConfigurationChangedBroadcastReceiver internal constructor(private val context: ReactApplicationContext) :
+  BroadcastReceiver() {
+
+  private var onReceiveCallback: ((intent: Intent?) -> Unit)? = null
+
+  override fun onReceive(context: Context?, intent: Intent?) {
+    this.onReceiveCallback?.invoke(intent)
+  }
+
+  fun setOnReceiveCallback(callback: (intent: Intent?) -> Unit) {
+    onReceiveCallback = callback
+  }
+
+  fun register() {
+    val filter = IntentFilter("${context.packageName}.CONFIGURATION_CHANGED")
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(this, filter, Context.RECEIVER_NOT_EXPORTED)
+    } else {
+      context.registerReceiver(this, filter)
+    }
+  }
+
+  fun unregister() {
+    context.unregisterReceiver(this)
+  }
+}

--- a/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/ConfigurationChangedBroadcastReceiver.kt
@@ -7,6 +7,13 @@ import android.content.IntentFilter
 import android.os.Build
 import com.facebook.react.bridge.ReactApplicationContext
 
+/**
+ * This custom broadcast receiver is needed to properly update the interface orientation when
+ * the user has disabled the automatic rotation.
+ *
+ * It listens for an explicit intent that the MainActivity can send in the onConfigurationChanged
+ * method and calls a custom callback that is set in the main implementation init
+ */
 class ConfigurationChangedBroadcastReceiver internal constructor(private val context: ReactApplicationContext) :
   BroadcastReceiver() {
 
@@ -20,6 +27,11 @@ class ConfigurationChangedBroadcastReceiver internal constructor(private val con
     onReceiveCallback = callback
   }
 
+  /**
+   * This method registers the receiver by checking the api we are currently running with.
+   * With the latest changes in Android 14, we need to explicitly set the `Context.RECEIVER_NOT_EXPORTED`
+   * flag.
+   */
   fun register() {
     val filter = IntentFilter("${context.packageName}.CONFIGURATION_CHANGED")
 

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -15,6 +15,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     )
   )
   private var mLifecycleListener = LifecycleListener()
+  private var mBroadcastReceiver = ConfigurationChangedBroadcastReceiver(context)
 
   private var initialSupportedInterfaceOrientations = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
   private var lastInterfaceOrientation = Orientation.UNKNOWN
@@ -31,24 +32,31 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
 
     mAutoRotationObserver.enable()
 
+    mBroadcastReceiver.setOnReceiveCallback {
+      // TODO: IMPLEMENT LOGIC TO COMPUTE INTERFACE PROPERLY
+    }
+
     context.addLifecycleEventListener(mLifecycleListener)
     mLifecycleListener.setOnHostResumeCallback {
       if (!didComputeInitialDeviceOrientation || areOrientationSensorsEnabled) {
         mOrientationSensorsEventListener.enable()
       }
       mAutoRotationObserver.enable()
+      mBroadcastReceiver.register()
     }
     mLifecycleListener.setOnHostPauseCallback {
       if (initialized && areOrientationSensorsEnabled) {
         mOrientationSensorsEventListener.disable()
         mAutoRotationObserver.disable()
       }
+      mBroadcastReceiver.unregister()
     }
     mLifecycleListener.setOnHostDestroyCallback {
       if (areOrientationSensorsEnabled) {
         mOrientationSensorsEventListener.disable()
         mAutoRotationObserver.disable()
       }
+      mBroadcastReceiver.unregister()
     }
 
     initialSupportedInterfaceOrientations =
@@ -89,15 +97,16 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
       return
     }
 
-    val lastInterfaceOrientationIsAlreadyInLandscape = lastInterfaceOrientation == Orientation.LANDSCAPE_RIGHT
-      || lastInterfaceOrientation == Orientation.LANDSCAPE_LEFT
-      if (lastInterfaceOrientationIsAlreadyInLandscape) {
-        updateLastInterfaceOrientationTo(lastInterfaceOrientation)
-        return;
-      }
+    val lastInterfaceOrientationIsAlreadyInLandscape =
+      lastInterfaceOrientation == Orientation.LANDSCAPE_RIGHT
+        || lastInterfaceOrientation == Orientation.LANDSCAPE_LEFT
+    if (lastInterfaceOrientationIsAlreadyInLandscape) {
+      updateLastInterfaceOrientationTo(lastInterfaceOrientation)
+      return;
+    }
 
     val systemDefaultLandscapeOrientation = Orientation.LANDSCAPE_RIGHT
-      updateLastInterfaceOrientationTo(systemDefaultLandscapeOrientation)
+    updateLastInterfaceOrientationTo(systemDefaultLandscapeOrientation)
   }
 
   fun unlock() {
@@ -165,7 +174,8 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
       return
     }
 
-    val supportsLandscape = mUtils.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
+    val supportsLandscape =
+      mUtils.getRequestedOrientation() == ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
     if (isLocked && !supportsLandscape) {
       return
     }
@@ -191,8 +201,9 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
      * Instead, we check that its value is either LANDSCAPE_RIGHT or LANDSCAPE_LEFT, otherwise we
      * exit
      */
-    val newInterfaceOrientationIsNotLandscape = newInterfaceOrientation != Orientation.LANDSCAPE_RIGHT
-      && newInterfaceOrientation != Orientation.LANDSCAPE_LEFT;
+    val newInterfaceOrientationIsNotLandscape =
+      newInterfaceOrientation != Orientation.LANDSCAPE_RIGHT
+        && newInterfaceOrientation != Orientation.LANDSCAPE_LEFT;
     if (supportsLandscape && newInterfaceOrientationIsNotLandscape) {
       return
     }

--- a/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationDirectorModuleImpl.kt
@@ -33,7 +33,7 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     mAutoRotationObserver.enable()
 
     mBroadcastReceiver.setOnReceiveCallback {
-      // TODO: IMPLEMENT LOGIC TO COMPUTE INTERFACE PROPERLY
+      adaptInterfaceTo(lastDeviceOrientation, false)
     }
 
     context.addLifecycleEventListener(mLifecycleListener)
@@ -169,8 +169,8 @@ class OrientationDirectorModuleImpl internal constructor(private val context: Re
     }
   }
 
-  private fun adaptInterfaceTo(deviceOrientation: Orientation) {
-    if (!mAutoRotationObserver.getLastAutoRotationStatus()) {
+  private fun adaptInterfaceTo(deviceOrientation: Orientation, checkLastAutoRotationStatus: Boolean = true) {
+    if (checkLastAutoRotationStatus && !mAutoRotationObserver.getLastAutoRotationStatus()) {
       return
     }
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme"
-      android:supportsRtl="true">>
+      android:supportsRtl="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/example/android/app/src/main/java/com/orientationdirectorexample/MainActivity.kt
+++ b/example/android/app/src/main/java/com/orientationdirectorexample/MainActivity.kt
@@ -1,10 +1,13 @@
 package com.orientationdirectorexample
 
+import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver
 
 class MainActivity : ReactActivity() {
 
@@ -19,9 +22,24 @@ class MainActivity : ReactActivity() {
    * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
-      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    val orientationDirectorCustomAction =
+      "${packageName}.${ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION}"
+
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
+
+    this.sendBroadcast(intent)
   }
 }

--- a/plugin/__tests__/__snapshots__/withRNOrientationMainActivity.spec.ts.snap
+++ b/plugin/__tests__/__snapshots__/withRNOrientationMainActivity.spec.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withRNOrientationMainActivity updates the MainActivity.kt with both import and method implementation 1`] = `
+"package com.orientationdirectorexample
+
+import android.content.Intent
+import android.content.res.Configuration
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+// React Native Orientation Director @generated begin @react-native-orientation-director/library-import - expo prebuild (DO NOT MODIFY) sync-dd77fee7fe624fed474053ea60c3105920a01a6a
+import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver
+
+// React Native Orientation Director @generated end @react-native-orientation-director/library-import
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "OrientationDirectorExample"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+// React Native Orientation Director @generated begin @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation - expo prebuild (DO NOT MODIFY) sync-7a5cdf10057b2ddf1bcf4593bf408862cbed5473
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    val orientationDirectorCustomAction =
+      packageName + "." + ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION
+
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
+
+    this.sendBroadcast(intent)
+  }
+
+// React Native Orientation Director @generated end @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation
+
+}
+"
+`;

--- a/plugin/__tests__/fixtures/MainActivity.kt
+++ b/plugin/__tests__/fixtures/MainActivity.kt
@@ -1,0 +1,30 @@
+package com.orientationdirectorexample
+
+import android.content.Intent
+import android.content.res.Configuration
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "OrientationDirectorExample"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+
+}

--- a/plugin/__tests__/withRNOrientationMainActivity.spec.ts
+++ b/plugin/__tests__/withRNOrientationMainActivity.spec.ts
@@ -15,8 +15,4 @@ describe('withRNOrientationMainActivity', function () {
     const result = ktFileUpdater(mainActivity);
     expect(result).toMatchSnapshot();
   });
-
-  it('updates the MainActivity.java with both the import the method implementation', async function () {
-    // TODO: Implement java test
-  });
 });

--- a/plugin/__tests__/withRNOrientationMainActivity.spec.ts
+++ b/plugin/__tests__/withRNOrientationMainActivity.spec.ts
@@ -1,0 +1,22 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { ktFileUpdater } from '../src/withRNOrientationMainActivity';
+
+describe('withRNOrientationMainActivity', function () {
+  beforeEach(function () {
+    jest.resetAllMocks();
+  });
+
+  it('updates the MainActivity.kt with both import and method implementation', async function () {
+    const mainActivityPath = path.join(__dirname, './fixtures/MainActivity.kt');
+    const mainActivity = await fs.promises.readFile(mainActivityPath, 'utf-8');
+
+    const result = ktFileUpdater(mainActivity);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('updates the MainActivity.java with both the import the method implementation', async function () {
+    // TODO: Implement java test
+  });
+});

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -7,6 +7,7 @@ import {
 import { withAppBridgingHeaderMod } from './custom-mod/withBridgingHeader';
 import { withRNOrientationAppDelegate } from './withRNOrientationAppDelegate';
 import { withRNOrientationBridgingHeader } from './withRNOrientationBridgingHeader';
+import { withRNOrientationMainActivity } from './withRNOrientationMainActivity';
 
 /**
  * So, expo config plugin are awesome and the documentation is well written, but I still needed to look around to see
@@ -22,6 +23,7 @@ const withRNOrientationDirector: ConfigPlugin = (config) => {
   return withPlugins(config, [
     withRNOrientationAppDelegate,
     withRNOrientationBridgingHeader,
+    withRNOrientationMainActivity,
     withAppBridgingHeaderMod,
   ]);
 };

--- a/plugin/src/withRNOrientationMainActivity.ts
+++ b/plugin/src/withRNOrientationMainActivity.ts
@@ -25,8 +25,6 @@ function getCompatibleFileUpdater(
   language: ApplicationProjectFile['language']
 ): (originalContents: string) => string {
   switch (language) {
-    case 'java':
-      return javaFileUpdater;
     case 'kt':
       return ktFileUpdater;
     default:
@@ -79,9 +77,4 @@ export function ktFileUpdater(originalContents: string): string {
   });
 
   return implementationMergeResults.contents;
-}
-
-export function javaFileUpdater(originalContents: string): string {
-  // TODO: Implement java file update
-  return originalContents;
 }

--- a/plugin/src/withRNOrientationMainActivity.ts
+++ b/plugin/src/withRNOrientationMainActivity.ts
@@ -1,0 +1,86 @@
+import {
+  type ConfigPlugin,
+  type ExportedConfigWithProps,
+  withMainActivity,
+} from '@expo/config-plugins';
+import { type ApplicationProjectFile } from '@expo/config-plugins/build/android/Paths';
+import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
+
+export const withRNOrientationMainActivity: ConfigPlugin = (config) => {
+  return withMainActivity(config, readMainActivityFileAndUpdateContents);
+};
+
+async function readMainActivityFileAndUpdateContents(
+  config: ExportedConfigWithProps<ApplicationProjectFile>
+): Promise<ExportedConfigWithProps<ApplicationProjectFile>> {
+  const { modResults: mainActivityFile } = config;
+
+  const worker = getCompatibleFileUpdater(mainActivityFile.language);
+  mainActivityFile.contents = worker(mainActivityFile.contents);
+
+  return config;
+}
+
+function getCompatibleFileUpdater(
+  language: ApplicationProjectFile['language']
+): (originalContents: string) => string {
+  switch (language) {
+    case 'java':
+      return javaFileUpdater;
+    case 'kt':
+      return ktFileUpdater;
+    default:
+      throw new Error(
+        `Cannot add React Native Orientation Director code to MainActivity of language "${language}"`
+      );
+  }
+}
+
+export function ktFileUpdater(originalContents: string): string {
+  const libraryImportCodeBlock =
+    'import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver\n';
+  const rightBeforeClassDeclaration = /class MainActivity\s+\w+/g;
+
+  const importMergeResults = mergeContents({
+    tag: '@react-native-orientation-director/library-import',
+    src: originalContents,
+    newSrc: libraryImportCodeBlock,
+    anchor: rightBeforeClassDeclaration,
+    offset: 0,
+    comment: '// React Native Orientation Director',
+  });
+
+  const onConfigurationChangedCodeBlock = `override fun onConfigurationChanged(newConfig: Configuration) {
+  super.onConfigurationChanged(newConfig)
+
+  val orientationDirectorCustomAction =
+    "\${packageName}.\${ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION}"
+
+  val intent =
+    Intent(orientationDirectorCustomAction).apply {
+      putExtra("newConfig", newConfig)
+      setPackage(packageName)
+    }
+
+  this.sendBroadcast(intent)
+}\n`;
+
+  const rightBeforeLastClosingBrace = /super\.onCreate/g;
+  const pasteInTheListJustAfterTheClosingBracket = 2;
+
+  const implementationMergeResults = mergeContents({
+    tag: '@react-native-orientation-director/supportedInterfaceOrientationsFor-implementation',
+    src: importMergeResults.contents,
+    newSrc: onConfigurationChangedCodeBlock,
+    anchor: rightBeforeLastClosingBrace,
+    offset: pasteInTheListJustAfterTheClosingBracket,
+    comment: '// React Native Orientation Director',
+  });
+
+  return implementationMergeResults.contents;
+}
+
+export function javaFileUpdater(originalContents: string): string {
+  // TODO: Implement java file update
+  return originalContents;
+}

--- a/plugin/src/withRNOrientationMainActivity.ts
+++ b/plugin/src/withRNOrientationMainActivity.ts
@@ -39,7 +39,7 @@ function getCompatibleFileUpdater(
 export function ktFileUpdater(originalContents: string): string {
   const libraryImportCodeBlock =
     'import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver\n';
-  const rightBeforeClassDeclaration = /class MainActivity\s+\w+/g;
+  const rightBeforeClassDeclaration = /class MainActivity/g;
 
   const importMergeResults = mergeContents({
     tag: '@react-native-orientation-director/library-import',
@@ -50,20 +50,21 @@ export function ktFileUpdater(originalContents: string): string {
     comment: '// React Native Orientation Director',
   });
 
-  const onConfigurationChangedCodeBlock = `override fun onConfigurationChanged(newConfig: Configuration) {
-  super.onConfigurationChanged(newConfig)
+  const onConfigurationChangedCodeBlock = `
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
 
-  val orientationDirectorCustomAction =
-    "\${packageName}.\${ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION}"
+    val orientationDirectorCustomAction =
+      packageName + "." + ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION
 
-  val intent =
-    Intent(orientationDirectorCustomAction).apply {
-      putExtra("newConfig", newConfig)
-      setPackage(packageName)
-    }
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
 
-  this.sendBroadcast(intent)
-}\n`;
+    this.sendBroadcast(intent)
+  }\n`;
 
   const rightBeforeLastClosingBrace = /super\.onCreate/g;
   const pasteInTheListJustAfterTheClosingBracket = 2;


### PR DESCRIPTION
# Goal

This PR fixes #58 that currently affect the library, specifically: when the user disables the `auto rotation` feature, the system prompts the user with an helpful icon that the user can tap to manually rotate the interface to the desired orientation, based on the last device orientation.
This means tho, that currently we don't intercept it and do not update the interface accordingly.

This PR implements a new Broadcast Receiver that intercepts the `MainActivity`.`onConfigurationChanged` call through a custom explicit intent.
It also means that the developer has to update its MainActivity with the following onConfigurationChanged override:

```kotlin

override fun onConfigurationChanged(newConfig: Configuration) {
    super.onConfigurationChanged(newConfig)

    val orientationDirectorCustomAction =
      "${packageName}.${ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION}"

    val intent =
      Intent(orientationDirectorCustomAction).apply {
        putExtra("newConfig", newConfig)
        setPackage(packageName)
      }

    this.sendBroadcast(intent)
}

```

> Note: on Expo, this android setup is handled by the plugin.

## Useful Links

- [Broadcast Overview](https://developer.android.com/develop/background-work/background-tasks/broadcasts#manifest-declared-receivers)
- [Intents and Intents Filters](https://developer.android.com/guide/components/intents-filters)
