### PR TITLE
fix(plugin): missing intent and configuration imports logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ You can install the package like any other Expo package, using the following com
 npx expo install react-native-orientation-director
 ```
 
-Then, you need to add the plugin to your app.json file:
+## Setup
+
+### Expo
+
+Simply add the library plugin to your `app.json` file:
 
 ```json
 {
@@ -66,9 +70,9 @@ This way, Expo will handle the native setup for you during `prebuild`.
 
 > Note: only SDK 50 and above are supported, the plugin is configured to handle only the kotlin template.
 
-## Setup
+### Bare
 
-### Android
+#### Android
 
 This library uses a custom broadcast receiver to handle the manual orientation changes: when the user disables the
 autorotation feature and the system prompts the user to rotate the device, the library will listen to the broadcast
@@ -96,12 +100,12 @@ override fun onConfigurationChanged(newConfig: Configuration) {
 
 Nothing else is required for Android.
 
-### iOS
+#### iOS
 
 To properly handle interface orientation changes in iOS, you need to update your AppDelegate file. Since React Native
 0.77, the AppDelegate has been migrated to Swift, so see the instructions below for both Swift and Objective-C.
 
-#### Objective-C
+##### Objective-C
 
 In your AppDelegate.h file, import "OrientationDirector.h" and implement supportedInterfaceOrientationsForWindow method as follows:
 
@@ -114,7 +118,7 @@ In your AppDelegate.h file, import "OrientationDirector.h" and implement support
 }
 ```
 
-#### Swift
+##### Swift
 
 You need to create a [bridging header](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift#Import-Code-Within-an-App-Target)
 to import the library, as shown below:

--- a/plugin/__tests__/__snapshots__/withRNOrientationMainActivity.spec.ts.snap
+++ b/plugin/__tests__/__snapshots__/withRNOrientationMainActivity.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`withRNOrientationMainActivity updates the MainActivity.kt with both import and method implementation 1`] = `
+exports[`withRNOrientationMainActivity skips the MainActivity.kt configuration import when it's already set 1`] = `
 "package com.orientationdirectorexample
 
-import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
 import com.facebook.react.ReactActivity
@@ -11,9 +10,127 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
-// React Native Orientation Director @generated begin @react-native-orientation-director/library-import - expo prebuild (DO NOT MODIFY) sync-dd77fee7fe624fed474053ea60c3105920a01a6a
+// React Native Orientation Director @generated begin @react-native-orientation-director/system-intent-import - expo prebuild (DO NOT MODIFY) sync-e6b9f54e19ab3cfd8689165dc8aa1ae37ba84e44
+import android.content.Intent
+// React Native Orientation Director @generated end @react-native-orientation-director/system-intent-import
+// React Native Orientation Director @generated begin @react-native-orientation-director/library-import - expo prebuild (DO NOT MODIFY) sync-7169e02357214d7bab1282e0a498c9c731ada6ad
 import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver
+// React Native Orientation Director @generated end @react-native-orientation-director/library-import
+class MainActivity : ReactActivity() {
 
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "OrientationDirectorExample"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+// React Native Orientation Director @generated begin @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation - expo prebuild (DO NOT MODIFY) sync-7a5cdf10057b2ddf1bcf4593bf408862cbed5473
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    val orientationDirectorCustomAction =
+      packageName + "." + ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION
+
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
+
+    this.sendBroadcast(intent)
+  }
+
+// React Native Orientation Director @generated end @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation
+
+}
+"
+`;
+
+exports[`withRNOrientationMainActivity skips the MainActivity.kt intent import when it's already set 1`] = `
+"package com.orientationdirectorexample
+
+import android.content.Intent
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+// React Native Orientation Director @generated begin @react-native-orientation-director/system-configuration-import - expo prebuild (DO NOT MODIFY) sync-e946440a29a0e93549862b7c63f1655b232ef6fb
+import android.content.res.Configuration
+// React Native Orientation Director @generated end @react-native-orientation-director/system-configuration-import
+// React Native Orientation Director @generated begin @react-native-orientation-director/library-import - expo prebuild (DO NOT MODIFY) sync-7169e02357214d7bab1282e0a498c9c731ada6ad
+import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver
+// React Native Orientation Director @generated end @react-native-orientation-director/library-import
+class MainActivity : ReactActivity() {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  override fun getMainComponentName(): String = "OrientationDirectorExample"
+
+  /**
+   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   */
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null)
+  }
+// React Native Orientation Director @generated begin @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation - expo prebuild (DO NOT MODIFY) sync-7a5cdf10057b2ddf1bcf4593bf408862cbed5473
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+
+    val orientationDirectorCustomAction =
+      packageName + "." + ConfigurationChangedBroadcastReceiver.CUSTOM_INTENT_ACTION
+
+    val intent =
+      Intent(orientationDirectorCustomAction).apply {
+        putExtra("newConfig", newConfig)
+        setPackage(packageName)
+      }
+
+    this.sendBroadcast(intent)
+  }
+
+// React Native Orientation Director @generated end @react-native-orientation-director/supportedInterfaceOrientationsFor-implementation
+
+}
+"
+`;
+
+exports[`withRNOrientationMainActivity updates the MainActivity.kt with both imports and method implementation 1`] = `
+"package com.orientationdirectorexample
+
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+
+// React Native Orientation Director @generated begin @react-native-orientation-director/system-intent-import - expo prebuild (DO NOT MODIFY) sync-e6b9f54e19ab3cfd8689165dc8aa1ae37ba84e44
+import android.content.Intent
+// React Native Orientation Director @generated end @react-native-orientation-director/system-intent-import
+// React Native Orientation Director @generated begin @react-native-orientation-director/system-configuration-import - expo prebuild (DO NOT MODIFY) sync-e946440a29a0e93549862b7c63f1655b232ef6fb
+import android.content.res.Configuration
+// React Native Orientation Director @generated end @react-native-orientation-director/system-configuration-import
+// React Native Orientation Director @generated begin @react-native-orientation-director/library-import - expo prebuild (DO NOT MODIFY) sync-7169e02357214d7bab1282e0a498c9c731ada6ad
+import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver
 // React Native Orientation Director @generated end @react-native-orientation-director/library-import
 class MainActivity : ReactActivity() {
 

--- a/plugin/__tests__/fixtures/MainActivityWithConfigurationImport.kt
+++ b/plugin/__tests__/fixtures/MainActivityWithConfigurationImport.kt
@@ -1,5 +1,6 @@
 package com.orientationdirectorexample
 
+import android.content.res.Configuration
 import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate

--- a/plugin/__tests__/fixtures/MainActivityWithIntentImport.kt
+++ b/plugin/__tests__/fixtures/MainActivityWithIntentImport.kt
@@ -1,5 +1,6 @@
 package com.orientationdirectorexample
 
+import android.content.Intent
 import android.os.Bundle
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate

--- a/plugin/__tests__/withRNOrientationMainActivity.spec.ts
+++ b/plugin/__tests__/withRNOrientationMainActivity.spec.ts
@@ -8,8 +8,30 @@ describe('withRNOrientationMainActivity', function () {
     jest.resetAllMocks();
   });
 
-  it('updates the MainActivity.kt with both import and method implementation', async function () {
+  it('updates the MainActivity.kt with both imports and method implementation', async function () {
     const mainActivityPath = path.join(__dirname, './fixtures/MainActivity.kt');
+    const mainActivity = await fs.promises.readFile(mainActivityPath, 'utf-8');
+
+    const result = ktFileUpdater(mainActivity);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("skips the MainActivity.kt intent import when it's already set", async function () {
+    const mainActivityPath = path.join(
+      __dirname,
+      './fixtures/MainActivityWithIntentImport.kt'
+    );
+    const mainActivity = await fs.promises.readFile(mainActivityPath, 'utf-8');
+
+    const result = ktFileUpdater(mainActivity);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("skips the MainActivity.kt configuration import when it's already set", async function () {
+    const mainActivityPath = path.join(
+      __dirname,
+      './fixtures/MainActivityWithConfigurationImport.kt'
+    );
     const mainActivity = await fs.promises.readFile(mainActivityPath, 'utf-8');
 
     const result = ktFileUpdater(mainActivity);

--- a/plugin/src/withRNOrientationMainActivity.ts
+++ b/plugin/src/withRNOrientationMainActivity.ts
@@ -35,13 +35,16 @@ function getCompatibleFileUpdater(
 }
 
 export function ktFileUpdater(originalContents: string): string {
+  const systemImportsContents =
+    updateContentsWithSystemImports(originalContents);
+
   const libraryImportCodeBlock =
-    'import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver\n';
+    'import com.orientationdirector.implementation.ConfigurationChangedBroadcastReceiver';
   const rightBeforeClassDeclaration = /class MainActivity/g;
 
   const importMergeResults = mergeContents({
     tag: '@react-native-orientation-director/library-import',
-    src: originalContents,
+    src: systemImportsContents,
     newSrc: libraryImportCodeBlock,
     anchor: rightBeforeClassDeclaration,
     offset: 0,
@@ -77,4 +80,52 @@ export function ktFileUpdater(originalContents: string): string {
   });
 
   return implementationMergeResults.contents;
+}
+
+function updateContentsWithSystemImports(originalContents: string) {
+  const rightBeforeClassDeclaration = /class MainActivity/g;
+
+  let possibleUpdatedContents = originalContents;
+  possibleUpdatedContents = addIntentImportIfNecessary(possibleUpdatedContents);
+  possibleUpdatedContents = addConfigurationImportIfNecessary(
+    possibleUpdatedContents
+  );
+
+  return possibleUpdatedContents;
+
+  function addIntentImportIfNecessary(_contents: string) {
+    const systemIntentImportCodeBlock = 'import android.content.Intent';
+    if (_contents.includes(systemIntentImportCodeBlock)) {
+      return _contents;
+    }
+
+    const mergeResults = mergeContents({
+      tag: '@react-native-orientation-director/system-intent-import',
+      src: _contents,
+      newSrc: systemIntentImportCodeBlock,
+      anchor: rightBeforeClassDeclaration,
+      offset: 0,
+      comment: '// React Native Orientation Director',
+    });
+
+    return mergeResults.contents;
+  }
+  function addConfigurationImportIfNecessary(_contents: string) {
+    const systemConfigurationImportCodeBlock =
+      'import android.content.res.Configuration';
+    if (possibleUpdatedContents.includes(systemConfigurationImportCodeBlock)) {
+      return _contents;
+    }
+
+    const mergeResults = mergeContents({
+      tag: '@react-native-orientation-director/system-configuration-import',
+      src: possibleUpdatedContents,
+      newSrc: systemConfigurationImportCodeBlock,
+      anchor: rightBeforeClassDeclaration,
+      offset: 0,
+      comment: '// React Native Orientation Director',
+    });
+
+    return mergeResults.contents;
+  }
 }


### PR DESCRIPTION
# Goal

This PR fixes #60 by implementing the missing logic for the intent and configuration imports in Android using the expo plugin.

It skips the update if the imports already exist.