### PR TITLE
fix(iOS): ios 15 doesn't lock the interface using provided methods

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1332,7 +1332,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - react-native-orientation-director (2.4.0):
+  - react-native-orientation-director (2.5.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2076,7 +2076,7 @@ SPEC CHECKSUMS:
   React-logger: 368570a253f00879a1e4fea24ed4047e72e7bbf3
   React-Mapbuffer: c04fcda1c6281fc0a6824c7dcc1633dd217ac1ec
   React-microtasksnativemodule: ca2804a25fdcefffa0aa942aa23ab53b99614a34
-  react-native-orientation-director: 2dd845aa5c3a30c143f43103b30e6dcc0b0e9048
+  react-native-orientation-director: 6d154528f2f6aad982161d0824fcd175a18b79bd
   react-native-safe-area-context: 00d03dc688ba86664be66f9e3f203fc7d747d899
   React-NativeModulesApple: 452b86b29fae99ed0a4015dca3ad9cd222f88abf
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c

--- a/ios/implementation/OrientationDirectorImpl.swift
+++ b/ios/implementation/OrientationDirectorImpl.swift
@@ -155,7 +155,8 @@ import UIKit
                 print("\(OrientationDirectorImpl.TAG) - requestGeometryUpdate error", error)
             }
         } else {
-            UIDevice.current.setValue(mask.rawValue, forKey: "orientation")
+            let interfaceOrientation = self.utils.convertToInterfaceOrientationFrom(mask: mask)
+            UIDevice.current.setValue(interfaceOrientation.rawValue, forKey: "orientation")
             UIViewController.attemptRotationToDeviceOrientation()
         }
     }

--- a/ios/implementation/Utils.swift
+++ b/ios/implementation/Utils.swift
@@ -78,6 +78,21 @@ class Utils {
         }
     }
 
+    public func convertToInterfaceOrientationFrom(mask: UIInterfaceOrientationMask) -> UIInterfaceOrientation {
+      switch mask {
+        case .portrait:
+          return .portrait
+        case .landscapeRight:
+          return .landscapeRight
+        case .portraitUpsideDown:
+          return .portraitUpsideDown
+        case .landscapeLeft:
+          return .landscapeLeft
+        default:
+          return .unknown
+      }
+    }
+
     public func getInterfaceOrientation() -> UIInterfaceOrientation {
         guard let windowScene = self.getCurrentWindow()?.windowScene else {
             return UIInterfaceOrientation.unknown


### PR DESCRIPTION
# Goal

This PR fixes #75 by providing the right value type to the `UIDevice.current.setValue` method, from `UIInterfaceOrientationMask` to `UIInterfaceOrientation`.

It builds upon #74, so we need to merge that one first, do a rebase and then merge this one.