### PR TITLE
fix(android): increase tolerance to tilts and improve landscape checks

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/OrientationSensorsEventListener.kt
@@ -20,7 +20,8 @@ class OrientationSensorsEventListener(
   private var mMagneticFieldSensor: Sensor? =
     mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
 
-  private var hasRotationSensor: Boolean = mRotationSensor != null
+  private var hasRotationSensor: Boolean =
+   mRotationSensor != null
   private var hasAccelerometerAndMagneticFieldSensors: Boolean =
     mAccelerometerSensor != null && mMagneticFieldSensor != null
 

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -38,11 +38,13 @@ class Utils(private val context: ReactContext) {
     //
     //////////////////////////////////////
 
+    val isPitchInLandscapeModeRange = checkIfPitchIsInLandscapeModeRange(pitchDegrees)
+
     return when {
       rollDegrees.equals(-0f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_UP
       rollDegrees.equals(-180f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_DOWN
-      rollDegrees in tolerance..landscapeRightLimit - tolerance -> Orientation.LANDSCAPE_RIGHT
-      rollDegrees in landscapeLeftLimit + tolerance..-tolerance -> Orientation.LANDSCAPE_LEFT
+      rollDegrees in tolerance..landscapeRightLimit - tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_RIGHT
+      rollDegrees in landscapeLeftLimit + tolerance..-tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_LEFT
       pitchDegrees in portraitLimit..-0f -> Orientation.PORTRAIT
       else -> Orientation.PORTRAIT_UPSIDE_DOWN
     }
@@ -93,5 +95,10 @@ class Utils(private val context: ReactContext) {
     }
 
     return context.currentActivity!!.requestedOrientation;
+  }
+
+  private fun checkIfPitchIsInLandscapeModeRange(pitchDegrees: Float): Boolean {
+    val tolerance = 5f
+    return pitchDegrees > -tolerance && pitchDegrees < tolerance
   }
 }

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -26,8 +26,8 @@ class Utils(private val context: ReactContext) {
     val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
     // This is needed to account for inaccuracy due to subtle movements such as tilting
-    val pitchTolerance = 5f
-    val tolerance = 20f
+    val pitchTolerance = 15f
+    val rollTolerance = 20f
 
     //////////////////////////////////////
     // These limits are set based on SensorManager.getOrientation reference
@@ -44,8 +44,8 @@ class Utils(private val context: ReactContext) {
     return when {
       rollDegrees.equals(-0f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_UP
       rollDegrees.equals(-180f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_DOWN
-      rollDegrees in tolerance..landscapeRightLimit - tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_RIGHT
-      rollDegrees in landscapeLeftLimit + tolerance..-tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_LEFT
+      rollDegrees in rollTolerance..landscapeRightLimit - rollTolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_RIGHT
+      rollDegrees in landscapeLeftLimit + rollTolerance..-rollTolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_LEFT
       pitchDegrees in portraitLimit..pitchTolerance -> Orientation.PORTRAIT
       else -> Orientation.PORTRAIT_UPSIDE_DOWN
     }

--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -26,6 +26,7 @@ class Utils(private val context: ReactContext) {
     val rollDegrees = Math.toDegrees(rollRadians.toDouble()).toFloat()
 
     // This is needed to account for inaccuracy due to subtle movements such as tilting
+    val pitchTolerance = 5f
     val tolerance = 20f
 
     //////////////////////////////////////
@@ -38,14 +39,14 @@ class Utils(private val context: ReactContext) {
     //
     //////////////////////////////////////
 
-    val isPitchInLandscapeModeRange = checkIfPitchIsInLandscapeModeRange(pitchDegrees)
+    val isPitchInLandscapeModeRange = checkIfPitchIsInLandscapeModeRange(pitchDegrees, pitchTolerance)
 
     return when {
       rollDegrees.equals(-0f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_UP
       rollDegrees.equals(-180f) && (pitchDegrees.equals(0f) || pitchDegrees.equals(-0f)) -> Orientation.FACE_DOWN
       rollDegrees in tolerance..landscapeRightLimit - tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_RIGHT
       rollDegrees in landscapeLeftLimit + tolerance..-tolerance && isPitchInLandscapeModeRange -> Orientation.LANDSCAPE_LEFT
-      pitchDegrees in portraitLimit..-0f -> Orientation.PORTRAIT
+      pitchDegrees in portraitLimit..pitchTolerance -> Orientation.PORTRAIT
       else -> Orientation.PORTRAIT_UPSIDE_DOWN
     }
   }
@@ -97,8 +98,7 @@ class Utils(private val context: ReactContext) {
     return context.currentActivity!!.requestedOrientation;
   }
 
-  private fun checkIfPitchIsInLandscapeModeRange(pitchDegrees: Float): Boolean {
-    val tolerance = 5f
+  private fun checkIfPitchIsInLandscapeModeRange(pitchDegrees: Float, tolerance: Float): Boolean {
     return pitchDegrees > -tolerance && pitchDegrees < tolerance
   }
 }


### PR DESCRIPTION
# Goal

This PR fixes #77.

Currently it tries to do so by passing a value as the `maxReportLatencyUs` parameter when we register the sensor listeners, but I can't confirm the fix since I don't own a low end Android device with virtual sensors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved device orientation detection by introducing separate pitch and roll tolerances for greater accuracy.
  * Enhanced code clarity with minor formatting adjustments.

* **Bug Fixes**
  * Landscape mode detection now requires the device pitch to be near zero, reducing incorrect landscape identifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->