### PR TITLE
feat: setup package to use exports keyword and expose app.plugin.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,21 @@
   "version": "2.5.1",
   "description": "A Modern React Native library that allows you to access orientation",
   "main": "./lib/module/index.js",
-  "module": "./lib/module/index.js",
-  "types": "./lib/typescript/src/index.d.ts",
+  "types": "./lib/typescript/module/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/typescript/module/src/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      }
+    },
+    "./package.json": "./package.json",
+    "./app.plugin.js": "./app.plugin.js"
+  },
   "files": [
     "src",
     "lib",
@@ -155,18 +168,11 @@
     "source": "src",
     "output": "lib",
     "targets": [
-      [
-        "module",
-        {
-          "esm": true
-        }
-      ],
-      [
-        "typescript",
-        {
-          "project": "tsconfig.build.json"
-        }
-      ]
+      ["commonjs", {
+        "esm": true,
+        "sourceMaps": false }],
+      ["module", { "esm": true }],
+      "typescript"
     ]
   },
   "codegenConfig": {


### PR DESCRIPTION
# Goal

This PR updates the library configuration to:

1. Properly expose both CommonJS and ESM modules through the `exports` keyword;
2. Instruct react-native-builder-bob to emit both modules and typescript types so that metro bundler can find them;
3. Properly expose the `app.plugin.js` file so that Expo can find the plugin and use it in the CGN setup;

Thanks again to the community for the help.

More here: https://github.com/callstack/react-native-builder-bob/discussions/837