### PR TITLE
fix(android): portrait falsy report when degrees don't match clauses

### DIFF
--- a/android/src/main/java/com/orientationdirector/implementation/Utils.kt
+++ b/android/src/main/java/com/orientationdirector/implementation/Utils.kt
@@ -60,7 +60,7 @@ class Utils(private val context: ReactContext) {
       // Landscape right
       isValueCloseTo(roll, 90f, 45f) -> Orientation.LANDSCAPE_RIGHT
 
-      else -> Orientation.PORTRAIT
+      else -> Orientation.UNKNOWN
     }
   }
 


### PR DESCRIPTION
This PR fixes #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device orientation detection to more accurately handle edge cases when orientation state is ambiguous, ensuring more reliable and consistent app behavior during screen transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->